### PR TITLE
feat(alacritty): symlinked config with auto light/dark theming

### DIFF
--- a/config/alacritty/alacritty.toml
+++ b/config/alacritty/alacritty.toml
@@ -1,57 +1,48 @@
-[colors.bright]
-black = "#414868"
-blue = "#7aa2f7"
-cyan = "#7dcfff"
-green = "#9ece6a"
-magenta = "#bb9af7"
-red = "#f7768e"
-white = "#c0caf5"
-yellow = "#e0af68"
-
-[colors.normal]
-black = "#15161e"
-blue = "#7aa2f7"
-cyan = "#7dcfff"
-green = "#9ece6a"
-magenta = "#bb9af7"
-red = "#f7768e"
-white = "#a9b1d6"
-yellow = "#e0af68"
-
-[colors.primary]
-background = "#1a1b26"
-foreground = "#c0caf5"
+[general]
+import = [
+    "~/.local/share/alacritty/active-theme.toml",
+]
 
 [font]
 size = 13.0
+
+[font.normal]
+family = "FiraCode Nerd Font"
+style = "Regular"
+
 [font.bold]
 family = "FiraCode Nerd Font"
 style = "Bold"
-
-[font.bold_italic]
-family = "FiraCode Nerd Font"
-style = "Bold Italic"
-
-[font.glyph_offset]
-x = 0
-y = 0
 
 [font.italic]
 family = "FiraCode Nerd Font"
 style = "Italic"
 
-[font.normal]
+[font.bold_italic]
 family = "FiraCode Nerd Font"
-style = "Regular"
+style = "Bold Italic"
 
 [font.offset]
 x = 0
 y = 1
 
 [window]
-decorations = "none"
+decorations = "Buttonless"
+dynamic_title = true
 opacity = 0.95
 
-[window.padding]
-x = 8
-y = 8
+[env]
+TERM = "xterm-256color"
+
+[cursor.style]
+shape = "Block"
+blinking = "On"
+
+[cursor.vi_mode_style]
+shape = "Block"
+
+[scrolling]
+history = 10000
+
+[mouse]
+hide_when_typing = true

--- a/config/alacritty/theme-switcher.sh
+++ b/config/alacritty/theme-switcher.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Watches macOS appearance (light/dark) and updates the active alacritty theme.
+# Alacritty auto-reloads when the imported file changes.
+
+set -euo pipefail
+
+THEMES_DIR="${HOME}/.config/alacritty/themes"
+ACTIVE_THEME="${HOME}/.local/share/alacritty/active-theme.toml"
+
+mkdir -p "$(dirname "$ACTIVE_THEME")"
+
+get_appearance() {
+  if defaults read -g AppleInterfaceStyle &>/dev/null; then
+    echo "dark"
+  else
+    echo "light"
+  fi
+}
+
+apply_theme() {
+  local appearance="$1"
+  local theme_file
+  if [[ "$appearance" == "dark" ]]; then
+    theme_file="${THEMES_DIR}/catppuccin-mocha.toml"
+  else
+    theme_file="${THEMES_DIR}/catppuccin-latte.toml"
+  fi
+
+  ln -sf "$theme_file" "$ACTIVE_THEME"
+}
+
+# Apply immediately on start
+current=$(get_appearance)
+apply_theme "$current"
+
+# Poll for changes every 2 seconds
+while true; do
+  sleep 2
+  new=$(get_appearance)
+  if [[ "$new" != "$current" ]]; then
+    current="$new"
+    apply_theme "$current"
+  fi
+done

--- a/config/alacritty/themes/catppuccin-latte.toml
+++ b/config/alacritty/themes/catppuccin-latte.toml
@@ -1,0 +1,68 @@
+# Catppuccin Latte (Light)
+[colors.primary]
+background = "#eff1f5"
+foreground = "#4c4f69"
+dim_foreground = "#8c8fa1"
+bright_foreground = "#4c4f69"
+
+[colors.cursor]
+text = "#eff1f5"
+cursor = "#dc8a78"
+
+[colors.vi_mode_cursor]
+text = "#eff1f5"
+cursor = "#7287fd"
+
+[colors.search.matches]
+foreground = "#eff1f5"
+background = "#9ca0b0"
+
+[colors.search.focused_match]
+foreground = "#eff1f5"
+background = "#40a02b"
+
+[colors.footer_bar]
+foreground = "#eff1f5"
+background = "#9ca0b0"
+
+[colors.hints.start]
+foreground = "#eff1f5"
+background = "#df8e1d"
+
+[colors.hints.end]
+foreground = "#eff1f5"
+background = "#9ca0b0"
+
+[colors.selection]
+text = "#eff1f5"
+background = "#dc8a78"
+
+[colors.normal]
+black = "#5c5f77"
+red = "#d20f39"
+green = "#40a02b"
+yellow = "#df8e1d"
+blue = "#1e66f5"
+magenta = "#ea76cb"
+cyan = "#179299"
+white = "#acb0be"
+
+[colors.bright]
+black = "#6c6f85"
+red = "#d20f39"
+green = "#40a02b"
+yellow = "#df8e1d"
+blue = "#1e66f5"
+magenta = "#ea76cb"
+cyan = "#179299"
+white = "#bcc0cc"
+
+[colors.dim]
+black = "#5c5f77"
+red = "#d20f39"
+green = "#40a02b"
+yellow = "#df8e1d"
+blue = "#1e66f5"
+magenta = "#ea76cb"
+cyan = "#179299"
+white = "#acb0be"

--- a/config/alacritty/themes/catppuccin-mocha.toml
+++ b/config/alacritty/themes/catppuccin-mocha.toml
@@ -1,0 +1,68 @@
+# Catppuccin Mocha (Dark)
+[colors.primary]
+background = "#1e1e2e"
+foreground = "#cdd6f4"
+dim_foreground = "#7f849c"
+bright_foreground = "#cdd6f4"
+
+[colors.cursor]
+text = "#1e1e2e"
+cursor = "#f5e0dc"
+
+[colors.vi_mode_cursor]
+text = "#1e1e2e"
+cursor = "#b4befe"
+
+[colors.search.matches]
+foreground = "#1e1e2e"
+background = "#a6adc8"
+
+[colors.search.focused_match]
+foreground = "#1e1e2e"
+background = "#a6e3a1"
+
+[colors.footer_bar]
+foreground = "#1e1e2e"
+background = "#a6adc8"
+
+[colors.hints.start]
+foreground = "#1e1e2e"
+background = "#f9e2af"
+
+[colors.hints.end]
+foreground = "#1e1e2e"
+background = "#a6adc8"
+
+[colors.selection]
+text = "#1e1e2e"
+background = "#f5e0dc"
+
+[colors.normal]
+black = "#45475a"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#bac2de"
+
+[colors.bright]
+black = "#585b70"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#a6adc8"
+
+[colors.dim]
+black = "#45475a"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#bac2de"

--- a/flake.nix
+++ b/flake.nix
@@ -52,8 +52,10 @@
         overlaySet.customPackages
       ];
 
+      dotfilesPath = ".dotfiles";
+
       mkSystem = import ./lib/mkSystem.nix {
-        inherit inputs;
+        inherit inputs dotfilesPath;
         overlays = overlays;
         lib = nixpkgs.lib;
       };

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -3,6 +3,7 @@
   inputs,
   overlays,
   lib,
+  dotfilesPath,
 }:
 name:
 {
@@ -43,6 +44,7 @@ let
   # TODO: Remove once https://github.com/LnL7/nix-darwin/pull/1341 is merged
   primaryUser = builtins.head users;
   homeDirectory = "${if darwin then "/Users" else "/home"}/${primaryUser}";
+  absoluteDotfilesPath = "${homeDirectory}/${dotfilesPath}";
 
 in
 systemFunc {
@@ -86,7 +88,10 @@ systemFunc {
           inputs.sops-nix.homeManagerModules.sops
           inputs.nixvim.homeManagerModules.nixvim
         ];
-        extraSpecialArgs = { inherit inputs pkgs; };
+        extraSpecialArgs = {
+          inherit inputs pkgs;
+          dotfilesPath = absoluteDotfilesPath;
+        };
       };
     }
 

--- a/modules/home/programs.nix
+++ b/modules/home/programs.nix
@@ -1,5 +1,9 @@
 { pkgs, ... }:
 {
+  imports = [
+    ./programs/alacritty.nix
+  ];
+
   programs = {
     git = import ./programs/git.nix { };
     zsh = import ./programs/zsh.nix { inherit pkgs; };
@@ -9,7 +13,6 @@
     };
     ssh = import ./programs/ssh.nix { inherit pkgs; };
     gpg = import ./programs/gpg.nix;
-    alacritty = import ./programs/alacritty.nix { inherit pkgs; };
     tmux = import ./programs/tmux.nix { inherit pkgs; };
   };
 }

--- a/modules/home/programs/alacritty.nix
+++ b/modules/home/programs/alacritty.nix
@@ -1,76 +1,12 @@
-{ pkgs, ... }:
 {
-  enable = true;
-  package = pkgs.alacritty;
-  settings = {
-    font = {
-      normal = {
-        family = "FiraCode Nerd Font";
-        style = "Regular";
-      };
-      bold = {
-        family = "FiraCode Nerd Font";
-        style = "Bold";
-      };
-      italic = {
-        family = "FiraCode Nerd Font";
-        style = "Italic";
-      };
-      bold_italic = {
-        family = "FiraCode Nerd Font";
-        style = "Bold Italic";
-      };
-      size = 13.0;
+  pkgs,
+  config,
+  dotfilesPath,
+  ...
+}:
+{
+  home.packages = [ pkgs.alacritty ];
 
-      # Offset is the extra space around each character. offset.y can be thought of as modifying the line spacing
-      offset = {
-        x = 0;
-        y = 1;
-      };
-
-      # Glyph offset determines the locations of the glyphs within their cells with the default being at the bottom.
-      glyph_offset = {
-        x = 0;
-        y = 0;
-      };
-    };
-
-    # Terminal colors
-    colors = {
-      primary = {
-        background = "#1a1b26";
-        foreground = "#c0caf5";
-      };
-      normal = {
-        black = "#15161e";
-        red = "#f7768e";
-        green = "#9ece6a";
-        yellow = "#e0af68";
-        blue = "#7aa2f7";
-        magenta = "#bb9af7";
-        cyan = "#7dcfff";
-        white = "#a9b1d6";
-      };
-      bright = {
-        black = "#414868";
-        red = "#f7768e";
-        green = "#9ece6a";
-        yellow = "#e0af68";
-        blue = "#7aa2f7";
-        magenta = "#bb9af7";
-        cyan = "#7dcfff";
-        white = "#c0caf5";
-      };
-    };
-
-    # Window settings
-    window = {
-      padding = {
-        x = 8;
-        y = 8;
-      };
-      decorations = "none";
-      opacity = 0.95;
-    };
-  };
+  home.file.".config/alacritty".source =
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/config/alacritty";
 }

--- a/users/romaingrx/home-manager-darwin.nix
+++ b/users/romaingrx/home-manager-darwin.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   config,
+  dotfilesPath,
   ...
 }:
 let
@@ -17,8 +18,23 @@ in
   };
 
   home.file.".config/sketchybar".source =
-    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.dotfiles/config/sketchybar";
+    config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/config/sketchybar";
 
   home.sessionPath = [ "$HOME/.local/bin" ];
+
+  launchd.agents.alacritty-theme-switcher = {
+    enable = true;
+    config = {
+      Label = "com.romaingrx.alacritty-theme-switcher";
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${config.home.homeDirectory}/.config/alacritty/theme-switcher.sh"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "/tmp/alacritty-theme-switcher.log";
+      StandardErrorPath = "/tmp/alacritty-theme-switcher.err";
+    };
+  };
 
 })


### PR DESCRIPTION
- Switch alacritty to `mkOutOfStoreSymlink` for live config reload
- Add Catppuccin Mocha/Latte themes with auto macOS appearance switching
- Add `dotfilesPath` via `extraSpecialArgs` to avoid hardcoded paths