### PR TITLE
ci: eval-only on PRs, full builds on main, fail on warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: build
 # Heavy: real `nix build` of each host's system closure. Only runs on
 # push to `main` (where it warms Cachix for everyone) and on demand via
-# workflow_call. PRs get the fast eval-only check in check.yml instead.
+# workflow_call / workflow_dispatch. PRs get the fast eval-only check
+# in check.yml instead.
 on:
   push:
     branches: [main]
@@ -12,11 +13,28 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
-# Add a new host? Add a build-<host> job mirroring the ones below.
-
 jobs:
-  build-carl:
+  # Discover NixOS hosts so the build job can fan out automatically.
+  nixos:
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - id: get-configs
+        name: Get NixOS configurations
+        run: |
+          configs=$(nix eval --json .#nixosConfigurations --apply builtins.attrNames --option abort-on-warn true)
+          echo "configs=$configs" >> $GITHUB_OUTPUT
+    outputs:
+      configs: ${{ steps.get-configs.outputs.configs }}
+
+  build-nixos:
+    needs: nixos
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.nixos.outputs.configs) }}
     steps:
       - name: Free disk space
         run: |
@@ -29,11 +47,30 @@ jobs:
         with:
           name: romaingrx-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build nixosConfigurations.carl
-        run: nix build .#nixosConfigurations.carl.config.system.build.toplevel --print-build-logs --option abort-on-warn true
+      - name: Build nixosConfigurations.${{ matrix.config }}
+        run: nix build .#nixosConfigurations.${{ matrix.config }}.config.system.build.toplevel --print-build-logs --option abort-on-warn true
 
-  build-goddard:
+  # Discover Darwin hosts so the build job can fan out automatically.
+  darwin:
     runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - id: get-configs
+        name: Get Darwin configurations
+        run: |
+          configs=$(nix eval --json .#darwinConfigurations --apply builtins.attrNames --option abort-on-warn true)
+          echo "configs=$configs" >> $GITHUB_OUTPUT
+    outputs:
+      configs: ${{ steps.get-configs.outputs.configs }}
+
+  build-darwin:
+    needs: darwin
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.darwin.outputs.configs) }}
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
@@ -42,15 +79,15 @@ jobs:
         with:
           name: romaingrx-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build darwinConfigurations.goddard
-        run: nix build .#darwinConfigurations.goddard.system --print-build-logs --option abort-on-warn true
+      - name: Build darwinConfigurations.${{ matrix.config }}
+        run: nix build .#darwinConfigurations.${{ matrix.config }}.system --print-build-logs --option abort-on-warn true
 
   build-status:
     if: always()
-    needs: [build-carl, build-goddard]
+    needs: [build-nixos, build-darwin]
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if [[ "${{ needs.build-carl.result }}" == "failure" || "${{ needs.build-goddard.result }}" == "failure" ]]; then
+          if [[ "${{ needs.build-nixos.result }}" == "failure" || "${{ needs.build-darwin.result }}" == "failure" ]]; then
             exit 1
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,16 @@
 name: build
-# Heavy: real `nix build` of each host's system closure. Only runs on
-# push to `main` (where it warms Cachix for everyone) and on demand via
-# workflow_call / workflow_dispatch. PRs get the fast eval-only check
-# in check.yml instead.
+# Heavy: real `nix build` of each host's system closure. Runs on:
+#   - push to main → keeps Cachix warm for everyone post-merge
+#   - push to automation/** branches → warms Cachix for bot-generated
+#     PRs (flake-lock updates) so the closure is ready before the user
+#     pulls and rebuilds locally
+#   - workflow_call / workflow_dispatch → manual or chained triggers
+# Regular PRs get the fast eval-only check in check.yml instead.
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "automation/**"
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,5 @@
 name: build
-# Heavy: real `nix build` of each host's system closure. Runs on:
-#   - push to main → keeps Cachix warm for everyone post-merge
-#   - push to automation/** branches → warms Cachix for bot-generated
-#     PRs (flake-lock updates) so the closure is ready before the user
-#     pulls and rebuilds locally
-#   - workflow_call / workflow_dispatch → manual or chained triggers
-# Regular PRs get the fast eval-only check in check.yml instead.
+# automation/** is the flake-update bot — warms Cachix before merge.
 on:
   push:
     branches:
@@ -19,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Discover NixOS hosts so the build job can fan out automatically.
   nixos:
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +48,6 @@ jobs:
       - name: Build nixosConfigurations.${{ matrix.config }}
         run: nix build .#nixosConfigurations.${{ matrix.config }}.config.system.build.toplevel --print-build-logs --option abort-on-warn true
 
-  # Discover Darwin hosts so the build job can fan out automatically.
   darwin:
     runs-on: macos-14
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,91 +1,56 @@
 name: build
+# Heavy: real `nix build` of each host's system closure. Only runs on
+# push to `main` (where it warms Cachix for everyone) and on demand via
+# workflow_call. PRs get the fast eval-only check in check.yml instead.
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_call:
+  workflow_dispatch:
 
 concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  # Check NixOS configurations
-  nixos:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-      - id: get-configs
-        name: Get NixOS configurations
-        run: |
-          configs=$(nix eval --json .#nixosConfigurations --apply builtins.attrNames)
-          echo "configs=$configs" >> $GITHUB_OUTPUT
-    outputs:
-      configs: ${{ steps.get-configs.outputs.configs }}
+# Add a new host? Add a build-<host> job mirroring the ones below.
 
-  build-nixos:
-    needs: nixos
+jobs:
+  build-carl:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config: ${{ fromJson(needs.nixos.outputs.configs) }}
     steps:
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache
           sudo docker image prune --all --force
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v15
         with:
           name: romaingrx-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build ${{ matrix.config }}
-        run: |
-          echo "Building NixOS configuration: ${{ matrix.config }}"
-          nix build .#nixosConfigurations.${{ matrix.config }}.config.system.build.toplevel --print-build-logs
+      - name: Build nixosConfigurations.carl
+        run: nix build .#nixosConfigurations.carl.config.system.build.toplevel --print-build-logs --option abort-on-warn true
 
-  # Check Darwin configurations
-  darwin:
+  build-goddard:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-      - id: get-configs
-        name: Get Darwin configurations
-        run: |
-          configs=$(nix eval --json .#darwinConfigurations --apply builtins.attrNames)
-          echo "configs=$configs" >> $GITHUB_OUTPUT
-    outputs:
-      configs: ${{ steps.get-configs.outputs.configs }}
-
-  build-darwin:
-    needs: darwin
-    runs-on: macos-14
-    strategy:
-      fail-fast: false
-      matrix:
-        config: ${{ fromJson(needs.darwin.outputs.configs) }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v15
         with:
           name: romaingrx-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build ${{ matrix.config }}
-        run: |
-          echo "Building Darwin configuration: ${{ matrix.config }}"
-          nix build .#darwinConfigurations."${{ matrix.config }}".system --print-build-logs
+      - name: Build darwinConfigurations.goddard
+        run: nix build .#darwinConfigurations.goddard.system --print-build-logs --option abort-on-warn true
 
   build-status:
     if: always()
-    needs: [build-nixos, build-darwin]
+    needs: [build-carl, build-goddard]
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if [[ "${{ needs.build-nixos.result }}" == "failure" || "${{ needs.build-darwin.result }}" == "failure" ]]; then
+          if [[ "${{ needs.build-carl.result }}" == "failure" || "${{ needs.build-goddard.result }}" == "failure" ]]; then
             exit 1
           fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,16 +13,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: cachix/install-nix-action@v30
-
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v15
         with:
           name: romaingrx-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # Run the exact same pre-commit-check that runs locally via `nix develop`
-      # This ensures CI uses identical formatter version, file patterns, and exclusions
+      # Pre-commit hooks: nixfmt, deadnix, statix.
       # Defined in flake.nix: checks.x86_64-linux.pre-commit-check
-      - name: Run flake checks
-        run: nix flake check --print-build-logs
+      - name: Pre-commit hooks
+        run: nix flake check --print-build-logs --option abort-on-warn true
+
+      # Eval all host configurations. Catches eval errors (typos, missing
+      # options, broken module structure) without paying the cost of a
+      # full system build. Build still runs on push to main via build.yml.
+      - name: Evaluate host configurations
+        run: |
+          set -e
+          for host in $(nix eval --json .#nixosConfigurations --apply builtins.attrNames | nix run nixpkgs#jq -- -r '.[]'); do
+            echo "::group::nixosConfigurations.$host"
+            nix eval --raw ".#nixosConfigurations.$host.config.system.build.toplevel.drvPath" --option abort-on-warn true
+            echo
+            echo "::endgroup::"
+          done
+          for host in $(nix eval --json .#darwinConfigurations --apply builtins.attrNames | nix run nixpkgs#jq -- -r '.[]'); do
+            echo "::group::darwinConfigurations.$host"
+            nix eval --raw ".#darwinConfigurations.$host.system.drvPath" --option abort-on-warn true
+            echo
+            echo "::endgroup::"
+          done

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,14 +20,9 @@ jobs:
           name: romaingrx-dotfiles
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      # Pre-commit hooks: nixfmt, deadnix, statix.
-      # Defined in flake.nix: checks.x86_64-linux.pre-commit-check
       - name: Pre-commit hooks
         run: nix flake check --print-build-logs --option abort-on-warn true
 
-      # Eval all host configurations. Catches eval errors (typos, missing
-      # options, broken module structure) without paying the cost of a
-      # full system build. Build still runs on push to main via build.yml.
       - name: Evaluate host configurations
         run: |
           set -e

--- a/devcontainer.sh
+++ b/devcontainer.sh
@@ -4,6 +4,13 @@ set -e
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZSH_PLUGINS_DIR="$HOME/.zsh/plugins"
 
+# Detect arch for binary downloads.
+case "$(dpkg --print-architecture)" in
+  amd64) ARCH=x86_64 ;;
+  arm64) ARCH=arm64 ;;
+  *) echo "unsupported arch" >&2; exit 1 ;;
+esac
+
 # --- system packages ---
 sudo apt-get update && sudo apt-get install -y --no-install-recommends \
   tmux \
@@ -37,13 +44,13 @@ ZSHEOF
 
 # --- lazygit ---
 LAZYGIT_VERSION=$(curl -fsSL https://api.github.com/repos/jesseduffield/lazygit/releases/latest | grep -o '"tag_name": "[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
-curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz" -o /tmp/lazygit.tar.gz
+curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_${ARCH}.tar.gz" -o /tmp/lazygit.tar.gz
 sudo tar xzf /tmp/lazygit.tar.gz -C /usr/local/bin lazygit
 rm -f /tmp/lazygit.tar.gz
 
 # --- neovim ---
 NVIM_VERSION=$(curl -fsSL https://api.github.com/repos/neovim/neovim/releases/latest | grep -o '"tag_name": "[^"]*"' | cut -d'"' -f4)
-curl -fsSL "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-x86_64.tar.gz" -o /tmp/nvim.tar.gz
+curl -fsSL "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-${ARCH}.tar.gz" -o /tmp/nvim.tar.gz
 sudo tar xzf /tmp/nvim.tar.gz -C /usr/local --strip-components=1
 rm -f /tmp/nvim.tar.gz
 mkdir -p ~/.config

--- a/flake.nix
+++ b/flake.nix
@@ -64,10 +64,10 @@
 
     in
     {
-      # Formatter configuration - matches CI workflow (.github/workflows/nixfmt.yml)
+      # Formatter configuration - matches CI workflow (.github/workflows/check.yml)
       formatter = {
-        aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt-rfc-style;
-        x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt-rfc-style;
+        aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt;
+        x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixfmt;
       };
 
       # Pre-commit hooks
@@ -82,7 +82,7 @@
             hooks = {
               nixfmt-rfc-style = {
                 enable = true;
-                package = pkgs.nixfmt-rfc-style;
+                package = pkgs.nixfmt;
                 excludes = [ "third-party/" ];
               };
             };
@@ -100,7 +100,7 @@
           default = pkgs.mkShell {
             inherit (self.checks.${system}.pre-commit-check) shellHook;
             buildInputs = with pkgs; [
-              nixfmt-rfc-style
+              nixfmt
               deadnix
               statix
               pre-commit

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -48,7 +48,6 @@ let
 
 in
 systemFunc {
-  inherit system;
   modules = [
     # Basic system configuration
     {
@@ -92,7 +91,7 @@ systemFunc {
         users = usersHMConfig;
         sharedModules = [
           inputs.sops-nix.homeManagerModules.sops
-          inputs.nixvim.homeManagerModules.nixvim
+          inputs.nixvim.homeModules.nixvim
         ];
         extraSpecialArgs = {
           inherit inputs pkgs;

--- a/modules/home/packages.nix
+++ b/modules/home/packages.nix
@@ -12,7 +12,7 @@
       just
       biome
       nil
-      nixfmt-rfc-style
+      nixfmt
       bat
       jq
       yq

--- a/users/romaingrx/rust.nix
+++ b/users/romaingrx/rust.nix
@@ -2,8 +2,8 @@
 
 let
   # Using the stable toolchain from Fenix
-  rustToolchain = inputs.fenix.packages.${pkgs.system}.stable.toolchain;
-  # rust-analyzer = inputs.fenix.packages.${pkgs.system}.rust-analyzer;
+  rustToolchain = inputs.fenix.packages.${pkgs.stdenv.hostPlatform.system}.stable.toolchain;
+  # rust-analyzer = inputs.fenix.packages.${pkgs.stdenv.hostPlatform.system}.rust-analyzer;
 in
 {
   home.packages = [


### PR DESCRIPTION
Cuts PR feedback from ~20 minutes to ~1 minute by replacing the full system build on PRs with a fast evaluation pass. Full builds still happen on push to \`main\` (which keeps Cachix warm for everyone).

**What changes for PRs ([.github/workflows/check.yml](.github/workflows/check.yml)):**
- Replace \`cachix/install-nix-action@v30\` with \`DeterminateSystems/nix-installer-action\` (faster install) and add \`magic-nix-cache-action\` for free GHA-backed /nix/store caching layered under Cachix.
- After the existing pre-commit hooks, eval every host's \`config.system.build.toplevel.drvPath\`. Catches typos, broken module references, deprecated APIs — without realizing any derivation.
- All \`nix\` invocations pass \`--option abort-on-warn true\`, so any future evaluation warning fails the build instead of silently accumulating.

**What changes for main pushes ([.github/workflows/build.yml](.github/workflows/build.yml)):**
- Same installer/cache swap.
- Drops \`pull_request\` trigger — full builds only run on push to \`main\`, \`workflow_call\`, or manual dispatch.
- Drops the static eval-then-build matrix indirection (each host now gets a direct job; add a new host = add a new job).

**Warning fixes (prerequisite for \`--abort-on-warn\`):**
- [modules/home/packages.nix](modules/home/packages.nix), [flake.nix](flake.nix): drop \`pkgs.nixfmt-rfc-style\` in favor of \`pkgs.nixfmt\` (renamed upstream).
- [users/romaingrx/rust.nix](users/romaingrx/rust.nix): \`pkgs.system\` → \`pkgs.stdenv.hostPlatform.system\`.
- [lib/mkSystem.nix](lib/mkSystem.nix): stop passing \`system\` to \`nixosSystem\`/\`darwinSystem\` (modules already set \`nixpkgs.hostPlatform\`); rename \`inputs.nixvim.homeManagerModules\` → \`inputs.nixvim.homeModules\`.

**Tradeoff:** a PR can pass and then break on \`main\` if it introduces an actual derivation build failure that eval doesn't catch. For a single-committer personal repo this is acceptable; mitigation is small batched PRs + the \`abort-on-warn\` net catching most regressions.

**Followups:**
- Path filters on [build.yml](.github/workflows/build.yml) to skip system builds on docs-only / config-only changes.
- Nightly cron that runs \`flake update + build\` to keep Cachix warm even when no PRs land.

Verified locally: \`nix flake check --option abort-on-warn true\` green, \`nix eval ... --option abort-on-warn true\` green for both hosts, \`darwin-rebuild build --flake path:.#goddard\` succeeds.