### PR TITLE
feat: aerospace corne keymap float + nvim markview plugin

### DIFF
--- a/config/nvim/lua/plugins/markdown.lua
+++ b/config/nvim/lua/plugins/markdown.lua
@@ -1,0 +1,7 @@
+return {
+  "OXY2DEV/markview.nvim",
+  lazy = false,
+
+  -- Completion for `blink.cmp`
+  -- dependencies = { "saghen/blink.cmp" },
+}

--- a/modules/darwin/services/aerospace/aerospace.toml
+++ b/modules/darwin/services/aerospace/aerospace.toml
@@ -169,3 +169,9 @@ run = 'move-node-to-workspace M'
 [[on-window-detected]]
 if.app-id = 'com.electron.wispr-flow.accessibility-mac-app'
 run = 'layout floating'
+
+# Float the keymap-drawer cheat sheet so it overlays instead of tiling.
+[[on-window-detected]]
+if.app-id = 'com.apple.Preview'
+if.window-title-regex-substring = 'corne\.png'
+run = 'layout floating'


### PR DESCRIPTION
Two small unrelated tweaks bundled because they were sitting in the same working tree.

- [aerospace.toml](modules/darwin/services/aerospace/aerospace.toml): float the corne keymap-drawer PNG when opened in Preview, so it overlays workspaces instead of tiling.
- [config/nvim/lua/plugins/markdown.lua](config/nvim/lua/plugins/markdown.lua): add [markview.nvim](https://github.com/OXY2DEV/markview.nvim) for rendered markdown in Neovim.