### PR TITLE
ci: drop magic-nix-cache, allow check dispatch, PAT for flake-update bot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,6 @@ jobs:
           sudo docker image prune --all --force
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v15
         with:
           name: romaingrx-dotfiles
@@ -71,7 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v15
         with:
           name: romaingrx-dotfiles

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v15
         with:
           name: romaingrx-dotfiles

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: check-${{ github.ref }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,10 +12,13 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: DeterminateSystems/nix-installer-action@main
+      # PAT (falls back to GITHUB_TOKEN). Token-driven events don't trigger
+      # downstream workflows, so without a PAT the bot's PR has no CI.
       - uses: DeterminateSystems/update-flake-lock@main
         with:
           branch: automation/flake-update
           pr-title: "chore(flake): update flake inputs"
           pr-labels: dependencies
           pr-assignees: romaingrx
+          token: ${{ secrets.WORKFLOW_PAT || github.token }}


### PR DESCRIPTION
Three CI hygiene fixes bundled together.

- **[build.yml](.github/workflows/build.yml), [check.yml](.github/workflows/check.yml)**: drop `DeterminateSystems/magic-nix-cache-action@main`. The action no longer works for unauthenticated users — on Linux it errors with a FlakeHub auth message, and on macOS it hangs indefinitely on `ECONNREFUSED 127.0.0.1`, deadlocking `build-darwin` until cancelled. Cachix (`romaingrx-dotfiles`) already provides binary caching.
- **[check.yml](.github/workflows/check.yml)**: add `workflow_dispatch` so the workflow can be re-triggered manually (useful when token-driven events skip it, like we just hit on #22).
- **[update.yml](.github/workflows/update.yml)**: pass `secrets.WORKFLOW_PAT` to `update-flake-lock` so the bot's pushes and PRs trigger downstream `check.yml` and `build.yml`. Falls back to `GITHUB_TOKEN` if the secret is unset (current behavior — no regression).