### PR TITLE
fix(sketchybar): recover display transitions

### DIFF
--- a/config/sketchybar/helpers/aerospace.sh
+++ b/config/sketchybar/helpers/aerospace.sh
@@ -61,6 +61,16 @@ aerospace_current_mode() {
 	aerospace_query list-modes --current || true
 }
 
+aerospace_monitor_count() {
+	local count
+
+	count="$(aerospace_query list-monitors --count || true)"
+	case "$count" in
+	"" | *[!0-9]*) printf "0" ;;
+	*) printf "%s" "$count" ;;
+	esac
+}
+
 aerospace_workspace_state() {
 	local workspace="$1"
 	local state
@@ -120,4 +130,17 @@ aerospace_trigger_workspace_change() {
 	"$sketchybar" --trigger aerospace_workspace_change \
 		FOCUSED_WORKSPACE="${focused:-${1:-}}" \
 		PREV_WORKSPACE="${PREV_WORKSPACE:-}"
+}
+
+aerospace_trigger_monitor_change() {
+	local focused monitor sketchybar
+
+	focused="$(aerospace_focused_workspace)"
+	monitor="$(aerospace_query list-monitors --focused --format "%{monitor-appkit-nsscreen-screens-id}" || true)"
+	sketchybar="$(sketchybar_bin)"
+	[ -n "$sketchybar" ] || return 1
+
+	"$sketchybar" --trigger aerospace_monitor_change \
+		TARGET_MONITOR="$monitor" \
+		FOCUSED_WORKSPACE="$focused"
 }

--- a/config/sketchybar/helpers/display_map.sh
+++ b/config/sketchybar/helpers/display_map.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+_DISPLAY_MAP_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_DISPLAY_MAP_HELPER_DIR/aerospace.sh"
+unset _DISPLAY_MAP_HELPER_DIR
+
+display_map_cache_file() {
+	printf "%s" "${SKETCHYBAR_DISPLAY_MAP_CACHE:-${TMPDIR:-/tmp}/sketchybar-display-map-${UID:-$(/usr/bin/id -u)}.cache}"
+}
+
+display_map_appkit_direct_display_ids() {
+	/usr/bin/osascript -l JavaScript <<'EOF'
+ObjC.import("AppKit");
+
+const screens = $.NSScreen.screens;
+const lines = [];
+for (let i = 0; i < screens.count; i++) {
+	const screen = screens.objectAtIndex(i);
+	const displayID = ObjC.unwrap(screen.deviceDescription.objectForKey("NSScreenNumber"));
+	lines.push(`${i + 1}|${displayID}`);
+}
+lines.join("\n");
+EOF
+}
+
+display_map_sketchybar_display_for_direct_display_id() {
+	local direct_display_id="$1"
+	local jq_bin displays
+
+	case "$direct_display_id" in
+	"" | *[!0-9]*) return 1 ;;
+	esac
+
+	jq_bin="$(command -v jq 2>/dev/null || true)"
+	[ -n "$jq_bin" ] || return 1
+
+	displays="$(sketchybar_query displays || true)"
+	[ -n "$displays" ] || return 1
+
+	printf "%s" "$displays" |
+		"$jq_bin" -r --arg direct_display_id "$direct_display_id" '
+			.[] |
+			select(((.DirectDisplayID // 0) | tostring) == $direct_display_id) |
+			.["arrangement-id"]
+		' |
+		head -n 1
+}
+
+display_map_build() {
+	local appkit_screen_id direct_display_id sketchybar_display
+
+	display_map_appkit_direct_display_ids |
+		while IFS="|" read -r appkit_screen_id direct_display_id; do
+			[ -n "$appkit_screen_id" ] || continue
+			sketchybar_display="$(display_map_sketchybar_display_for_direct_display_id "$direct_display_id")"
+			[ -n "$sketchybar_display" ] || continue
+
+			printf "%s|%s|%s\n" "$appkit_screen_id" "$direct_display_id" "$sketchybar_display"
+		done
+}
+
+display_map_refresh() {
+	local cache_file tmp_file
+
+	cache_file="$(display_map_cache_file)"
+	tmp_file="${cache_file}.$$"
+
+	display_map_build >"$tmp_file" || {
+		rm -f "$tmp_file"
+		return 1
+	}
+
+	if [ ! -s "$tmp_file" ]; then
+		rm -f "$tmp_file"
+		return 1
+	fi
+
+	mv "$tmp_file" "$cache_file"
+}
+
+display_map_invalidate() {
+	rm -f "$(display_map_cache_file)"
+}
+
+display_map_entry_count() {
+	local cache_file
+
+	cache_file="$(display_map_cache_file)"
+	[ -r "$cache_file" ] || return 1
+
+	awk -F "|" 'NF >= 3 { count++ } END { print count + 0 }' "$cache_file"
+}
+
+display_map_lookup_appkit_screen_id() {
+	local appkit_screen_id="$1"
+	local cache_file display
+
+	case "$appkit_screen_id" in
+	"" | *[!0-9]*) return 1 ;;
+	esac
+
+	cache_file="$(display_map_cache_file)"
+	if [ ! -r "$cache_file" ]; then
+		display_map_refresh || return 1
+	fi
+
+	display="$(awk -F "|" -v appkit_screen_id="$appkit_screen_id" '$1 == appkit_screen_id { print $3; exit }' "$cache_file")"
+	if [ -z "$display" ]; then
+		display_map_refresh || return 1
+		display="$(awk -F "|" -v appkit_screen_id="$appkit_screen_id" '$1 == appkit_screen_id { print $3; exit }' "$cache_file")"
+	fi
+
+	[ -n "$display" ] || return 1
+	printf "%s" "$display"
+}
+
+display_map_sketchybar_display_for_appkit_screen_id() {
+	local appkit_screen_id="$1"
+	local display
+
+	display="$(display_map_lookup_appkit_screen_id "$appkit_screen_id")" || return 1
+	sketchybar_display_exists "$display" || return 1
+
+	printf "%s" "$display"
+}
+
+display_map_appkit_screen_id_from_workspace_state() {
+	local state="$1"
+	local workspace is_focused is_visible appkit_screen_id layout
+
+	IFS="|" read -r workspace is_focused is_visible appkit_screen_id layout <<EOF
+$state
+EOF
+
+	[ -n "$appkit_screen_id" ] || return 1
+	printf "%s" "$appkit_screen_id"
+}
+
+display_map_sketchybar_display_for_workspace() {
+	local workspace="$1"
+	local state="${2:-}"
+	local appkit_screen_id
+
+	[ -n "$workspace" ] || return 1
+
+	if [ -z "$state" ]; then
+		state="$(aerospace_workspace_state "$workspace")"
+	fi
+
+	appkit_screen_id="$(display_map_appkit_screen_id_from_workspace_state "$state")" || return 1
+	display_map_sketchybar_display_for_appkit_screen_id "$appkit_screen_id"
+}

--- a/config/sketchybar/helpers/sketchybar.sh
+++ b/config/sketchybar/helpers/sketchybar.sh
@@ -25,6 +25,56 @@ sketchybar_query() {
 	"$bin" --query "$@" 2>/dev/null
 }
 
+sketchybar_valid_display_ids() {
+	local jq_bin displays
+
+	jq_bin="$(command -v jq 2>/dev/null || true)"
+	[ -n "$jq_bin" ] || return 1
+
+	displays="$(sketchybar_query displays || true)"
+	[ -n "$displays" ] || return 1
+
+	printf "%s" "$displays" |
+		"$jq_bin" -r '.[] | select((.DirectDisplayID // 0) != 0) | .["arrangement-id"]'
+}
+
+sketchybar_valid_display_count() {
+	sketchybar_valid_display_ids | awk 'NF { count++ } END { print count + 0 }'
+}
+
+sketchybar_display_exists() {
+	local display="$1"
+
+	case "$display" in
+	"" | *[!0-9]*) return 1 ;;
+	esac
+
+	sketchybar_valid_display_ids | awk -v display="$display" '$1 == display { found = 1 } END { exit !found }'
+}
+
+sketchybar_fallback_display() {
+	local display
+
+	display="$(sketchybar_valid_display_ids | head -n 1)"
+	if [ -n "$display" ]; then
+		printf "%s" "$display"
+		return
+	fi
+
+	printf "1"
+}
+
+sketchybar_resolve_display() {
+	local display="$1"
+
+	if sketchybar_display_exists "$display"; then
+		printf "%s" "$display"
+		return
+	fi
+
+	sketchybar_fallback_display
+}
+
 sketchybar_has_placeholder_display() {
 	local jq_bin displays
 
@@ -35,7 +85,7 @@ sketchybar_has_placeholder_display() {
 	[ -n "$displays" ] || return 1
 
 	printf "%s" "$displays" |
-		"$jq_bin" -e '.[] | select(.DirectDisplayID == 0 or .["arrangement-id"] == 0)' >/dev/null 2>&1
+		"$jq_bin" -e '.[] | select((.DirectDisplayID // 0) == 0)' >/dev/null 2>&1
 }
 
 sketchybar_kickstart() {

--- a/config/sketchybar/plugins/display_recovery.sh
+++ b/config/sketchybar/plugins/display_recovery.sh
@@ -5,6 +5,7 @@ source "$SCRIPT_DIR/../helpers/env.sh"
 sketchybar_resolve_paths "$SCRIPT_DIR"
 
 source "$HELPER_DIR/sketchybar.sh"
+source "$HELPER_DIR/display_map.sh"
 source "$HELPER_DIR/aerospace.sh"
 
 case "${SENDER:-}" in
@@ -13,15 +14,30 @@ display_change | system_woke) ;;
 esac
 
 delay="${SKETCHYBAR_DISPLAY_RECOVERY_DELAY:-1}"
+attempts="${SKETCHYBAR_DISPLAY_RECOVERY_ATTEMPTS:-4}"
+interval="${SKETCHYBAR_DISPLAY_RECOVERY_INTERVAL:-1}"
 stamp_file="${TMPDIR:-/tmp}/sketchybar-display-recovery.stamp"
 
 (
 	sleep "$delay"
 
-	if sketchybar_has_placeholder_display; then
-		sketchybar_debounced_kickstart "$stamp_file"
-		exit 0
-	fi
+	i=1
+	while [ "$i" -le "$attempts" ]; do
+		sketchybar_count="$(sketchybar_valid_display_count)"
+		aerospace_count="$(aerospace_monitor_count)"
 
-	aerospace_trigger_workspace_change
+		if [ "$sketchybar_count" -gt 0 ] &&
+			{ [ "$aerospace_count" -eq 0 ] || [ "$sketchybar_count" -eq "$aerospace_count" ]; }; then
+			display_map_refresh || exit 0
+			aerospace_trigger_monitor_change
+			aerospace_trigger_workspace_change
+			exit 0
+		fi
+
+		i=$((i + 1))
+		sleep "$interval"
+	done
+
+	display_map_invalidate
+	sketchybar_debounced_kickstart "$stamp_file"
 ) >/dev/null 2>&1 &

--- a/config/sketchybar/plugins/space.sh
+++ b/config/sketchybar/plugins/space.sh
@@ -8,6 +8,7 @@ source "$CONFIG_DIR/colors.sh"
 source "$CONFIG_DIR/icons.sh"
 source "$HELPER_DIR/aerospace.sh"
 source "$HELPER_DIR/app_icons.sh"
+source "$HELPER_DIR/display_map.sh"
 source "$HELPER_DIR/text.sh"
 
 MAX_WORKSPACE_APPS="${MAX_WORKSPACE_APPS:-4}"
@@ -115,6 +116,7 @@ state="$(aerospace_workspace_state "$workspace")"
 IFS="|" read -r _workspace is_focused is_visible display layout <<EOF
 $state
 EOF
+display="$(display_map_sketchybar_display_for_workspace "$workspace" "$state" || true)"
 
 event_focused_workspace="${FOCUSED_WORKSPACE:-}"
 focused_workspace="${event_focused_workspace:-$(aerospace_focused_workspace)}"
@@ -147,9 +149,14 @@ elif [ "$window_count" -eq 0 ]; then
 	label_color="$GREY"
 fi
 
+display_properties=()
+if [ -n "$display" ]; then
+	display_properties=(display="$display")
+fi
+
 sketchybar --set "$NAME" \
 	drawing=on \
-	display="${display:-1}" \
+	"${display_properties[@]}" \
 	icon="$workspace" \
 	icon.color="$icon_color" \
 	label="$apps_label" \


### PR DESCRIPTION
## Summary
- Add a cached display-map helper that translates the AeroSpace AppKit screen index through `CGDirectDisplayID` into the SketchyBar arrangement id.
- Ignore the closed-laptop placeholder display when resolving drawable SketchyBar displays.
- Rebind workspace items through the display map, leaving existing placement untouched while the map is temporarily unavailable during topology changes.
- Debounce display-change recovery, refresh AeroSpace monitor/workspace events when topology is healthy, and restart SketchyBar only when display counts do not settle.
- Make the display recovery plugin executable so SketchyBar can run it from subscribed events.

## Validation
- `bash -n config/sketchybar/helpers/display_map.sh`
- `bash -n config/sketchybar/helpers/sketchybar.sh`
- `bash -n config/sketchybar/helpers/aerospace.sh`
- `bash -n config/sketchybar/plugins/display_recovery.sh`
- `bash -n config/sketchybar/plugins/space.sh`
- `git diff --check`
- Reloaded SketchyBar and verified AppKit screen indexes map through `CGDirectDisplayID` to the expected SketchyBar displays.
- Triggered `aerospace_workspace_change` manually and verified representative workspace pills land on the translated displays.