### PR TITLE
perf(sketchybar): repaint workspace highlight instantly on switch

### DIFF
--- a/config/sketchybar/items/spaces.sh
+++ b/config/sketchybar/items/spaces.sh
@@ -35,9 +35,7 @@ aerospace_workspaces | while IFS= read -r sid; do
 		popup.background.corner_radius=5 \
 		popup.align=left \
 		popup.height=26 \
-		script="$PLUGIN_DIR/space.sh" \
-		click_script="$PLUGIN_DIR/space_click.sh $sid" \
-		--subscribe "$item" aerospace_workspace_change aerospace_monitor_change
+		click_script="$PLUGIN_DIR/space_click.sh $sid"
 
 	sketchybar --add item "$item.summary" "popup.$item" \
 		--set "$item.summary" \
@@ -70,3 +68,14 @@ aerospace_workspaces | while IFS= read -r sid; do
 		i=$((i + 1))
 	done
 done
+
+# One hidden controller drives every workspace indicator: on each event it runs
+# spaces_update.sh, which either fast-paints two items or kicks a full reconcile
+# (see plugins/spaces_update.sh). updates=on so it still fires while hidden.
+sketchybar --add item spaces_controller left \
+	--set spaces_controller drawing=off updates=on \
+	script="$PLUGIN_DIR/spaces_update.sh" \
+	--subscribe spaces_controller aerospace_workspace_change aerospace_monitor_change
+
+# Paint initial state now instead of waiting for the first workspace switch.
+"$PLUGIN_DIR/spaces_update.sh" >/dev/null 2>&1 || true

--- a/config/sketchybar/plugins/spaces_reconcile.sh
+++ b/config/sketchybar/plugins/spaces_reconcile.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+# Authoritative full repaint of every AeroSpace workspace indicator.
+#
+# This is the slow-but-correct path. It runs:
+#   - synchronously for init/forced paint and for aerospace_monitor_change
+#     (display assignments may have changed), and
+#   - in the background after a plain workspace switch, to reconcile whatever the
+#     instant 2-set in spaces_update.sh could not know without querying:
+#     multi-monitor PREV visibility, empty-vs-occupied icon shade, and app-icon
+#     labels (which change when move-node-to-workspace fires this same event).
+#
+# It derives the whole picture in two queries and repaints in one batched
+# `sketchybar --set`. Popups are intentionally not built here (space_click.sh
+# rebuilds the popup when it is opened).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers/env.sh"
+sketchybar_resolve_paths "$SCRIPT_DIR"
+
+source "$CONFIG_DIR/colors.sh"
+source "$CONFIG_DIR/icons.sh"
+source "$HELPER_DIR/aerospace.sh"
+source "$HELPER_DIR/app_icons.sh"
+source "$HELPER_DIR/display_map.sh"
+
+MAX_WORKSPACE_APPS="${MAX_WORKSPACE_APPS:-4}"
+AEROSPACE_FALLBACK_WORKSPACES="${AEROSPACE_FALLBACK_WORKSPACES:-1 2 3 B C M U S}"
+
+# Only used to seed focus in the synthesized fallback below; the real repaint
+# reads focus from each workspace's own query flag, never from this env value.
+event_focused="${FOCUSED_WORKSPACE:-}"
+
+# Display assignment only changes when a workspace moves monitors (or at init),
+# never on a plain workspace switch. Resolving it costs osascript/jq/sketchybar
+# queries, so skip it on the hot switch path and only recompute otherwise.
+do_display=1
+[ "$SENDER" = "aerospace_workspace_change" ] && do_display=0
+
+# One call: full state for every workspace.
+state_all="$(aerospace_query list-workspaces --all \
+	--format "%{workspace}|%{workspace-is-focused}|%{workspace-is-visible}|%{monitor-appkit-nsscreen-screens-id}")"
+
+# One call: every window, grouped later by workspace (labels + counts).
+windows_all="$(aerospace_query list-windows --all \
+	--format "%{workspace}|%{app-name}|%{app-bundle-id}")"
+
+# If the server didn't answer, synthesize a minimal state so the bar still paints.
+if [ -z "$state_all" ]; then
+	for ws in $AEROSPACE_FALLBACK_WORKSPACES; do
+		f="false"
+		[ "$ws" = "$event_focused" ] && f="true"
+		state_all="${state_all}${ws}|${f}|${f}|
+"
+	done
+fi
+
+# Memo of appkit-screen-id -> sketchybar display (tab-separated lines), so we
+# resolve each distinct monitor at most once instead of per-workspace.
+display_memo=""
+
+resolve_display() {
+	local appkit="$1"
+	local hit d
+
+	[ -n "$appkit" ] || return 1
+
+	hit="$(printf "%s" "$display_memo" | awk -F'\t' -v k="$appkit" '$1==k{print $2; exit}')"
+	if [ -n "$hit" ]; then
+		[ "$hit" = "-" ] && return 1
+		printf "%s" "$hit"
+		return 0
+	fi
+
+	d="$(display_map_sketchybar_display_for_appkit_screen_id "$appkit" 2>/dev/null || true)"
+	if [ -n "$d" ]; then
+		display_memo="${display_memo}${appkit}	${d}
+"
+		printf "%s" "$d"
+		return 0
+	fi
+
+	display_memo="${display_memo}${appkit}	-
+"
+	return 1
+}
+
+workspace_window_count() {
+	printf "%s\n" "$windows_all" |
+		awk -F"|" -v ws="$1" '$1==ws && $2!="" {c++} END{print c+0}'
+}
+
+workspace_label() {
+	local workspace="$1"
+	local app bundle icons count total
+	icons=""
+	count=0
+	total=0
+
+	while IFS="|" read -r app bundle; do
+		[ -n "$app" ] || continue
+		total=$((total + 1))
+		if [ "$count" -lt "$MAX_WORKSPACE_APPS" ]; then
+			icons="${icons}${icons:+ }$(app_ligature "$bundle" "$app")"
+			count=$((count + 1))
+		fi
+	done <<EOF
+$(printf "%s\n" "$windows_all" | awk -F"|" -v ws="$workspace" '$1==ws && $2!="" && !seen[$2"|"$3]++ {print $2"|"$3}')
+EOF
+
+	if [ "$total" -gt "$MAX_WORKSPACE_APPS" ]; then
+		icons="$icons +$((total - MAX_WORKSPACE_APPS))"
+	fi
+
+	printf "%s" "$icons"
+}
+
+args=()
+while IFS="|" read -r ws is_focused is_visible appkit; do
+	[ -n "$ws" ] || continue
+
+	wlabel="$(workspace_label "$ws")"
+	wcount="$(workspace_window_count "$ws")"
+
+	# Focus comes from the query's own flag (current real state), NOT the
+	# inherited FOCUSED_WORKSPACE env, so an async reconcile that lands after
+	# several rapid switches still paints the latest truth rather than a stale
+	# event's focused workspace.
+	icon_color="$WHITE"
+	label_color="$GREY"
+	background_color="$TRANSPARENT"
+	background_drawing="off"
+	label_drawing="on"
+	[ -n "$wlabel" ] || label_drawing="off"
+
+	if [ "$is_focused" = "true" ]; then
+		icon_color="$WHITE"
+		label_color="$WHITE"
+		background_color=0x55ffffff
+		background_drawing="on"
+	elif [ "$is_visible" = "true" ]; then
+		icon_color="$BLUE"
+		label_color="$WHITE"
+		background_color=0x22ffffff
+		background_drawing="on"
+	elif [ "$wcount" -eq 0 ]; then
+		icon_color="$GREY"
+		label_color="$GREY"
+	fi
+
+	args+=(--set "space.$ws" drawing=on)
+	if [ "$do_display" = "1" ]; then
+		d="$(resolve_display "$appkit" || true)"
+		[ -n "$d" ] && args+=(display="$d")
+	fi
+	args+=(
+		icon="$ws"
+		icon.color="$icon_color"
+		label="$wlabel"
+		label.color="$label_color"
+		label.drawing="$label_drawing"
+		background.color="$background_color"
+		background.drawing="$background_drawing"
+	)
+done <<EOF
+$state_all
+EOF
+
+if [ "${#args[@]}" -gt 0 ]; then
+	sb="$(sketchybar_bin)"
+	[ -n "$sb" ] && "$sb" "${args[@]}"
+fi

--- a/config/sketchybar/plugins/spaces_update.sh
+++ b/config/sketchybar/plugins/spaces_update.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Entry point for the spaces_controller item (subscribed to workspace/monitor
+# events and run on init).
+#
+# Fast path: a plain workspace switch only changes the focus state of two
+# indicators, and AeroSpace already hands us FOCUSED_WORKSPACE and
+# PREV_WORKSPACE. So repaint just those two with ZERO queries (instant), then
+# kick a full reconcile in the background to fix what we can't know without
+# querying (multi-monitor PREV visibility, empty-vs-occupied shade, and labels
+# after move-node-to-workspace). Any wrong optimistic guess for PREV -- one that
+# is still visible on another monitor -- corrects within a frame, and that flash
+# is on the monitor you just left, not the one you moved to.
+#
+# Any other sender (init/forced paint, aerospace_monitor_change) goes straight to
+# the authoritative full repaint.
+#
+# This stays query-free on purpose: it sources only colors + sketchybar (not the
+# heavy aerospace/display helpers), and never shells out to aerospace/jq/query.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers/env.sh"
+sketchybar_resolve_paths "$SCRIPT_DIR"
+source "$CONFIG_DIR/colors.sh"
+source "$HELPER_DIR/sketchybar.sh"
+
+if [ "$SENDER" = "aerospace_workspace_change" ] && [ -n "${FOCUSED_WORKSPACE:-}" ]; then
+	focused="$FOCUSED_WORKSPACE"
+	prev="${PREV_WORKSPACE:-}"
+	sb="$(sketchybar_bin)"
+
+	if [ -n "$sb" ]; then
+		# Focused workspace -> highlighted.
+		args=(--set "space.$focused"
+			background.color=0x55ffffff
+			background.drawing=on
+			icon.color="$WHITE"
+			label.color="$WHITE")
+
+		# Previous workspace -> optimistically un-highlighted (assume it is now
+		# hidden, the common same-monitor case). Reconcile fixes the rest.
+		if [ -n "$prev" ] && [ "$prev" != "$focused" ]; then
+			args+=(--set "space.$prev"
+				background.drawing=off
+				icon.color="$WHITE"
+				label.color="$GREY")
+		fi
+
+		"$sb" "${args[@]}"
+	fi
+
+	# Authoritative reconcile, fully detached so it never blocks the highlight.
+	( SENDER=aerospace_workspace_change "$PLUGIN_DIR/spaces_reconcile.sh" >/dev/null 2>&1 & )
+	exit 0
+fi
+
+exec "$PLUGIN_DIR/spaces_reconcile.sh"

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -53,6 +53,8 @@
         AppleInterfaceStyleSwitchesAutomatically = true;
         "com.apple.mouse.tapBehavior" = 1; # Is not working with trackpad
         _HIHideMenuBar = true;
+        # Kills the half-second window resize/rebuild flash on AeroSpace workspace switches.
+        NSAutomaticWindowAnimationsEnabled = false;
       };
       dock = {
         autohide = true;


### PR DESCRIPTION
## Summary
Speeds up and smooths AeroSpace workspace switching (two related changes).

- **Instant bar highlight** — every workspace pill used to subscribe to `aerospace_workspace_change`, fanning out to ~32 `aerospace` queries per switch (~1.5s) and rebuilding invisible popups each time. Now a single hidden `spaces_controller` drives them:
  - [spaces_update.sh](config/sketchybar/plugins/spaces_update.sh): zero-query fast path repaints only the focused + previous pill from the event vars, then spawns a detached reconcile.
  - [spaces_reconcile.sh](config/sketchybar/plugins/spaces_reconcile.sh): authoritative repaint via one `list-workspaces` + one `list-windows` in a single batched `--set`; focus read from the query flag (race-safe under rapid switching); display resolution skipped on plain switches.
  - Popups now build on click, not on every switch.
- **No window-resize flash** — [default.nix](modules/darwin/default.nix): set `NSAutomaticWindowAnimationsEnabled = false` to drop the ~0.5s shrink-then-expand animation when AeroSpace moves windows on/off screen during a switch.

## Validation
- `bash -n` on the three sketchybar scripts; new plugins are executable (SketchyBar execs `script=` items directly)
- Pre-commit passing (nix fmt, deadnix, statix)
- Triggered `aerospace_workspace_change` against the running bar: highlight fast path ~15–40ms; reconcile produces correct focused/visible/hidden styling across the 3 monitors

Deploys via `darwin-rebuild switch` (required for the SketchyBar config and macOS default to take effect).
