### PR TITLE
chore(linux): drop the Cursor editor

### DIFF
--- a/config/hypr/bindings.conf
+++ b/config/hypr/bindings.conf
@@ -11,7 +11,6 @@ bindd = $mod, space, Menu, exec, rofi -show drun
 bindd = $mod SHIFT, V, Clipboard, exec, romaingrx-clipboard-history
 bindd = $mod, B, Browser, exec, romaingrx-launch-or-focus firefox
 bindd = $mod, M, Music, exec, romaingrx-launch-or-focus spotify
-bindd = $mod, C, Cursor, exec, romaingrx-launch-or-focus cursor
 bindd = $mod, N, Editor, exec, romaingrx-launch-editor
 bindd = $mod, A, Activity, exec, $terminal -e btop
 bindd = $mod, D, Docker, exec, $terminal -e lazydocker

--- a/users/romaingrx/home-manager-nixos.nix
+++ b/users/romaingrx/home-manager-nixos.nix
@@ -71,7 +71,6 @@ lib.mkMerge [
       wl-clipboard
       bibata-cursors
       spotify
-      code-cursor
       signal-desktop
       lazydocker
       btop


### PR DESCRIPTION
## What

Removes the **Cursor** editor from the Linux (`carl`) setup:

- Drop the `code-cursor` package from the NixOS home packages.
- Remove the now-dead `$mod + C` Hyprland launch binding (`romaingrx-launch-or-focus cursor`), freeing the keybind.

## Why

Cursor is no longer used. This stops pulling the editor into the `carl` build and reclaims the `$mod + C` shortcut.

## Notes

- Unrelated to the theme migration — the mouse-pointer cursor theme (Bibata) and the terminal text-caret colors are intentionally left untouched.
- `nix eval .#nixosConfigurations.carl…toplevel` still evaluates cleanly; pre-commit hooks (deadnix/nixfmt/statix) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed keyboard shortcut for Cursor application.
  * Updated system packages: removed code-cursor; added wl-clipboard, bibata-cursors, and Spotify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->