### PR TITLE
feat(theme): mirror reload-hook warnings to the system log

### DIFF
--- a/config/bin/romaingrx-theme-lib
+++ b/config/bin/romaingrx-theme-lib
@@ -188,6 +188,13 @@ theme_warn() {
 
   printf '%s\n' "$message" >&2
 
+  # Mirror to the system log (journald on Linux, the unified log on macOS) for
+  # observability alongside the file log. Best-effort: skipped when logger is
+  # absent, and never fatal.
+  if command -v logger >/dev/null 2>&1; then
+    printf '%s\n' "$message" | logger -t romaingrx-theme -p user.warning 2>/dev/null || true
+  fi
+
   log_file="$(theme_reload_hook_log)"
   mkdir -p -- "$(dirname -- "$log_file")" 2>/dev/null || return 0
   printf '%s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$message" >> "$log_file" 2>/dev/null || true

--- a/docs/theme-inventory.md
+++ b/docs/theme-inventory.md
@@ -93,8 +93,9 @@ deduplication pass.
 - Hooks also receive `ROMAINGRX_THEME_CURRENT`,
   `ROMAINGRX_THEME_GENERATED_ROOT`, and `ROMAINGRX_THEME_RUNTIME_ROOT`.
 - Hooks must be idempotent and quick. Long-running work should detach itself.
-- Hook failures are non-fatal; the core actuator writes warnings to stderr and
-  to `ROMAINGRX_THEME_RELOAD_HOOK_LOG`.
+- Hook failures are non-fatal; the core actuator writes warnings to stderr, to
+  `ROMAINGRX_THEME_RELOAD_HOOK_LOG`, and (best-effort) to the system log via
+  `logger -t romaingrx-theme` (journald on Linux, the unified log on macOS).
 - Hooks run after `theme_apply` and after Home Manager activation, so consumers
   can refresh after both manual theme switches and generated artifact updates.
 

--- a/tests/theme/runtime-contract.sh
+++ b/tests/theme/runtime-contract.sh
@@ -287,8 +287,9 @@ EOF
   assert_symlink_target "$root/state/theme/current" "$root/config/romaingrx/theme/generated/light"
   grep -q 'Warning: theme reload hook failed' "$root/error.log"
   grep -q 'Warning: theme reload hook failed' "$root/state/theme/reload-hooks.log"
-  # Mirrored to the system log via `logger -t romaingrx-theme`.
+  # Mirrored to the system log via `logger -t romaingrx-theme -p user.warning`.
   grep -q 'romaingrx-theme' "$root/syslog.capture"
+  grep -qF -- '-p user.warning' "$root/syslog.capture"
   grep -q 'Warning: theme reload hook failed' "$root/syslog.capture"
 }
 

--- a/tests/theme/runtime-contract.sh
+++ b/tests/theme/runtime-contract.sh
@@ -264,18 +264,32 @@ test_reload_hook_failure_is_nonfatal() {
 exit 42
 EOF
 
+  # Stub `logger` on PATH to capture the syslog mirror (args + piped message).
+  mkdir -p "$root/bin"
+  cat > "$root/bin/logger" <<EOF
+#!$BASH
+{ printf 'args: %s\n' "\$*"; cat; } >> "$root/syslog.capture"
+EOF
+  chmod +x "$root/bin/logger"
+
   reset_theme_env
   HOME="$root/home"
   XDG_CONFIG_HOME="$root/config"
   XDG_STATE_HOME="$root/state"
   ROMAINGRX_THEME_RELOAD_HOOKS_DIR="$root/hooks"
 
+  local saved_path="$PATH"
+  PATH="$root/bin:$PATH"
   theme_sync light 2> "$root/error.log"
+  PATH="$saved_path"
 
   assert_file_contents "$root/state/theme/appearance" "light"
   assert_symlink_target "$root/state/theme/current" "$root/config/romaingrx/theme/generated/light"
   grep -q 'Warning: theme reload hook failed' "$root/error.log"
   grep -q 'Warning: theme reload hook failed' "$root/state/theme/reload-hooks.log"
+  # Mirrored to the system log via `logger -t romaingrx-theme`.
+  grep -q 'romaingrx-theme' "$root/syslog.capture"
+  grep -q 'Warning: theme reload hook failed' "$root/syslog.capture"
 }
 
 test_first_run_bootstrap_uses_dark_default


### PR DESCRIPTION
## What

`theme_warn` in `config/bin/romaingrx-theme-lib` is the single logging sink for the reload-hook actuator. It already writes to **stderr** and to the **file log** (`ROMAINGRX_THEME_RELOAD_HOOK_LOG`). This adds a third, best-effort mirror to the **system log**:

```sh
printf '%s\n' "$message" | logger -t romaingrx-theme -p user.warning 2>/dev/null || true
```

- journald on Linux, the unified log on macOS — query with `journalctl -t romaingrx-theme` / `log show --predicate 'process == "logger"'` (or Console, filter `romaingrx-theme`).
- **Best-effort**: guarded by `command -v logger`, stderr suppressed, `|| true` — skipped when `logger` is absent and never fatal, so the runtime contract is unchanged.
- Tagged `romaingrx-theme` at `user.warning` priority for easy filtering.

## Test

The runtime-contract test (`test_reload_hook_failure_is_nonfatal`) now stubs `logger` on `PATH` and asserts the warning is mirrored with the correct tag, alongside the existing stderr + file-log assertions. Verified locally and in the Nix sandbox (`theme-runtime-contract` builds green).

## Scope

Mirrors the existing warning sink only (hook failures) — it does not add new success-level logging. Easy to extend later if you want lifecycle events in syslog too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warnings are now also mirrored to the system logger (journald on Linux / unified log on macOS); mirroring is best-effort and does not make failures fatal.

* **Documentation**
  * Clarified reload-hook behavior: failures are non-fatal and warnings are recorded to stderr, the reload-hook log, and the system log.

* **Tests**
  * Extended tests to verify warnings are emitted to the system log with the romaingrx-theme tag and user.warning priority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->