### PR TITLE
feat(darwin): expose tailscale cli from the MAS app

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -8,7 +8,9 @@ _: {
       upgrade = false;
     };
 
-    masApps = { };
+    masApps = {
+      Tailscale = 1475387142;
+    };
     taps = [ ];
 
     casks = [

--- a/users/romaingrx/home-manager-darwin.nix
+++ b/users/romaingrx/home-manager-darwin.nix
@@ -17,6 +17,8 @@ lib.mkIf pkgs.stdenv.isDarwin {
       SUDO_ASKPASS = "${askpass}/bin/askpass";
     };
     sessionPath = [ "$HOME/.local/bin" ];
+    # The MAS Tailscale app bundles the CLI but never links it onto PATH.
+    shellAliases.tailscale = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
     file.".config/sketchybar".source =
       config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/config/sketchybar";
   };


### PR DESCRIPTION
The Mac App Store Tailscale app bundles its CLI inside the app bundle but never links it onto PATH.

- declare the Tailscale MAS app in `homebrew.masApps` so nix-darwin tracks it
- alias `tailscale` to `/Applications/Tailscale.app/Contents/MacOS/Tailscale`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled macOS Homebrew “MAS apps” configuration to install the Tailscale app from the Mac App Store.
  * Added a macOS shell alias so the Tailscale command-line tool can be run reliably from the installed app bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->