### PR TITLE
feat(hosts): add brobot darwin host with per-host override seams

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,13 @@
           ];
           darwin = true;
         };
+        "brobot" = (mkSystem "brobot") {
+          system = "aarch64-darwin";
+          users = [
+            "romaingrx"
+          ];
+          darwin = true;
+        };
       };
     };
 }

--- a/hosts/darwin/brobot/default.nix
+++ b/hosts/darwin/brobot/default.nix
@@ -1,0 +1,21 @@
+{ ... }:
+{
+  imports = [
+    ../../../modules/darwin
+  ];
+
+  networking.hostName = "brobot";
+  networking.computerName = "brobot";
+
+  system.primaryUser = "romaingrx";
+
+  system.defaults.loginwindow.LoginwindowText = "Hand-built, loyal, little brother";
+
+  # Host-only overrides live with the host:
+  #   - system/darwin (dock, casks, macOS defaults) -> here, e.g.
+  #       homebrew.casks = [ "some-app" ];                          # list-merges with the shared set
+  #       system.defaults.dock.orientation = lib.mkForce "bottom";  # scalar -> mkForce to win
+  #       (add `lib` to the arg set above if you use lib.* here)
+  #   - home-manager (per-machine apps/programs) -> create ./home.nix
+  #       beside this file; mkSystem auto-imports it when present.
+}

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -29,6 +29,11 @@ let
   hostConfig = ../hosts/${systemType}/${name};
   usersOSConfig = builtins.map (user: ../users/${user}/${systemType}.nix) users;
 
+  # Optional per-host home-manager overrides, auto-imported only when present.
+  # Mirrors hostConfig (the per-host system module) for the home-manager layer.
+  hostHomeModule = ../hosts/${systemType}/${name}/home.nix;
+  hasHostHome = builtins.pathExists hostHomeModule;
+
   # Home Manager configurations
   usersHMConfigList = builtins.map (
     user: import ../users/${user}/home-manager.nix { inherit inputs pkgs; }
@@ -36,7 +41,9 @@ let
   usersHMConfig = builtins.listToAttrs (
     lib.lists.imap0 (i: config: {
       name = builtins.elemAt users i;
-      value = config;
+      value = {
+        imports = [ config ] ++ lib.optional hasHostHome hostHomeModule;
+      };
     }) usersHMConfigList
   );
 

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -34,18 +34,14 @@ let
   hostHomeModule = ../hosts/${systemType}/${name}/home.nix;
   hasHostHome = builtins.pathExists hostHomeModule;
 
-  # Home Manager configurations
-  usersHMConfigList = builtins.map (
-    user: import ../users/${user}/home-manager.nix { inherit inputs pkgs; }
-  ) users;
-  usersHMConfig = builtins.listToAttrs (
-    lib.lists.imap0 (i: config: {
-      name = builtins.elemAt users i;
-      value = {
-        imports = [ config ] ++ lib.optional hasHostHome hostHomeModule;
-      };
-    }) usersHMConfigList
-  );
+  # Home Manager configurations, keyed by user: each user's shared home config
+  # plus the optional per-host home.nix when it exists.
+  usersHMConfig = lib.genAttrs users (user: {
+    imports = [
+      (import ../users/${user}/home-manager.nix { inherit inputs pkgs; })
+    ]
+    ++ lib.optional hasHostHome hostHomeModule;
+  });
 
   # User-specific configurations
   # TODO: Remove once https://github.com/LnL7/nix-darwin/pull/1341 is merged
@@ -54,11 +50,19 @@ let
   absoluteDotfilesPath = "${homeDirectory}/${dotfilesPath}";
 
 in
+# The shared modules assume a single primary user per host (homeDirectory above
+# collapses to the first user). Fail loudly rather than silently misconfigure a
+# second user.
+assert lib.assertMsg (builtins.length users == 1)
+  "mkSystem: host '${name}' declares ${toString (builtins.length users)} users, but a host currently supports exactly one.";
 systemFunc {
   modules = [
     # Basic system configuration
     {
       nixpkgs = {
+        # Single source of truth for the platform: the flake `system` arg drives
+        # both the `pkgs` built above and the system module set here.
+        hostPlatform = system;
         config = {
           allowUnfree = true;
         };

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -22,12 +22,6 @@
     keep-outputs = true;
   };
 
-  # The platform the configuration will be used on.
-  nixpkgs = {
-    hostPlatform = "aarch64-darwin";
-    config.allowUnfree = true;
-  };
-
   system = {
     # Used for backwards compatibility
     stateVersion = 5;


### PR DESCRIPTION
Adds `brobot` (MacBook Pro M5) as a second darwin host for `romaingrx`, inheriting goddard's full config by default, plus a small cleanup of the multi-host assembly in `mkSystem`.

## New host
- `flake.nix` — register `darwinConfigurations.brobot` (aarch64-darwin)
- `hosts/darwin/brobot/default.nix` — host module importing the shared `modules/darwin` baseline; carries host identity and documents where system overrides go

## Per-host override seams
- **System / apps** (casks, dock, macOS defaults) → `hosts/darwin/brobot/default.nix` (lists merge, scalars use `lib.mkForce`)
- **Home / programs** → create `hosts/darwin/brobot/home.nix`; `mkSystem` auto-imports it via `builtins.pathExists` when present, mirroring the per-host system module
- **Add host #3 later** → one `flake.nix` entry + one host dir; nothing under `modules/` changes

## Assembly cleanup (same file, same concern)
- `nixpkgs.hostPlatform` now comes from the flake `system` arg in `mkSystem` instead of being hardcoded in `modules/darwin/default.nix` — one source of truth, so an Intel host #3 needs no shared-module edit
- per-user home-manager configs built with `lib.genAttrs` instead of `imap0` + `listToAttrs` index juggling
- a `lib.assertMsg` guard turns the implicit single-user assumption (`homeDirectory = head users`) into a loud build error

## Verification
- `nix eval` resolves all three hosts: brobot/goddard `aarch64-darwin`, carl `x86_64-linux` (no platform conflict); identity correct; goddard unchanged
- `deadnix` / `statix` / `nixfmt` clean — pre-commit hooks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new macOS host configuration, including device name, primary user setup, and a custom login screen message.
  * Expanded system setup to allow a per-machine home configuration when needed.

* **Bug Fixes**
  * Enforced a single primary user per host to prevent configuration mismatches and setup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->