### PR TITLE
docs: add new macOS host setup runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ nix fmt
 nix flake check
 ```
 
-Bootstrap a machine with:
+Bootstrap a fresh machine (installs Nix, clones to `~/.dotfiles`, switches):
 
 ```sh
-./scripts/bootstrap.sh
+curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/bootstrap.sh | bash
 ```
+
+See [docs/new-host-setup.md](docs/new-host-setup.md) for the manual prerequisites (the sops age key, plus a couple of permission grants).
 
 ## Known Issues and Limitations
 

--- a/docs/new-host-setup.md
+++ b/docs/new-host-setup.md
@@ -1,0 +1,23 @@
+# New macOS host
+
+`scripts/bootstrap.sh` installs Nix, clones to `~/.dotfiles`, and switches —
+Homebrew, the SSH and GPG keys (via sops), and everything else come from the switch.
+
+## Before
+
+Copy the sops age key from another host to `~/.config/sops/age/keys.txt` (mode `0600`).
+It's the only secret you carry over — the GPG and SSH keys decrypt from it on switch.
+
+## Bootstrap
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/bootstrap.sh | HOST=brobot bash
+```
+
+`HOST` defaults to `hostname -s`; the repo must land at `~/.dotfiles`.
+
+## After
+
+1. Grant Accessibility + Screen Recording when prompted: aerospace, sketchybar, jankyborders.
+2. Set Arc as the default browser (System Settings).
+3. Install `claude-code` (intentionally not in Nix, so it self-updates).


### PR DESCRIPTION
Concise new-host runbook reflecting the reduced manual steps from the readiness work:
- **one secret to carry over** (the sops age key) — GPG and SSH keys decrypt from it on switch (#65)
- **no App Store step** — Tailscale moved off the Mac App Store to a cask (#59)
- the `curl | bash` **one-liner** (bootstrap installs Nix + Homebrew, clones, switches; #64)

**Merge last** — it documents the end state of #59, #64, #65. From the brobot readiness audit.