### PR TITLE
feat(darwin): curate homebrew casks

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -8,9 +8,8 @@ _: {
       upgrade = false;
     };
 
-    masApps = {
-      Tailscale = 1475387142;
-    };
+    # No Mac App Store apps — avoids requiring an App Store sign-in on a new host.
+    masApps = { };
     taps = [ ];
 
     casks = [
@@ -18,12 +17,17 @@ _: {
       # modules/fonts.nix (pkgs.nerd-fonts.fira-code), so no cask is needed.
       "sf-symbols"
       "firefox"
-      "duckduckgo"
-      "wifiman"
       "anytype"
       "spotify"
-      "avogadro"
-      "onedrive"
+      # Daily-driver GUI apps. All ship a built-in updater (auto_updates), so
+      # Homebrew only bootstraps them and onActivation.upgrade stays off.
+      "1password"
+      "arc"
+      "claude"
+      "linear"
+      # Standalone, self-updating Tailscale GUI — replaces the Mac App Store
+      # version so a fresh host needs no App Store sign-in. Same /Applications path.
+      "tailscale-app"
     ];
     brews = [
       "watch"


### PR DESCRIPTION
Aligns the declared Homebrew set with daily use so a fresh brobot matches goddard, and removes the App Store dependency.

**Add** (self-updating): `1password`, `arc`, `claude`, `linear`, `tailscale-app`.
**Drop the Mac App Store Tailscale** (`masApps` now empty) — `tailscale-app` is the standalone self-updating cask at the same `/Applications/Tailscale.app` path (CLI alias unaffected). Removes the only reason a new host needs an App Store sign-in. One-time: re-auth your tailnet.
**Remove** (uninstalled on next switch via `cleanup`): `onedrive`, `duckduckgo`, `wifiman`, `avogadro`.

From the brobot readiness audit.