### PR TITLE
feat(darwin): codify mouse and trackpad input defaults

### DIFF
--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -37,6 +37,7 @@
     defaults = {
       trackpad = {
         Clicking = true;
+        TrackpadThreeFingerDrag = false;
       };
       NSGlobalDomain = {
         KeyRepeat = 2;
@@ -50,6 +51,9 @@
         # Kills the half-second window resize/rebuild flash on AeroSpace workspace switches.
         NSAutomaticWindowAnimationsEnabled = false;
       };
+      # com.apple.mouse.scaling is not a typed NSGlobalDomain option in nix-darwin,
+      # so set the pointer tracking speed via the freeform CustomUserPreferences path.
+      CustomUserPreferences.NSGlobalDomain."com.apple.mouse.scaling" = 0.875;
       dock = {
         autohide = true;
         orientation = "left";


### PR DESCRIPTION
Captures two intentional input customizations live on goddard but not yet declared, so brobot feels identical:

- `trackpad.TrackpadThreeFingerDrag = false`
- pointer tracking speed `com.apple.mouse.scaling = 0.875` — routed through `system.defaults.CustomUserPreferences.NSGlobalDomain` because it is not a typed nix-darwin option.

Verified both resolve via `nix eval`. From the brobot readiness audit (PR 3 of 5).