### PR TITLE
fix(darwin): pre-create the screenshots directory

### DIFF
--- a/users/romaingrx/home-manager-darwin.nix
+++ b/users/romaingrx/home-manager-darwin.nix
@@ -23,6 +23,13 @@ lib.mkIf pkgs.stdenv.isDarwin {
       config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/config/sketchybar";
   };
 
+  # screencapture.location and the dock persistent-others entry both point at
+  # ~/Pictures/screenshots; create it so a fresh host does not silently fall back
+  # to ~/Desktop for screenshots.
+  home.activation.ensureScreenshotDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    run mkdir -p "${config.home.homeDirectory}/Pictures/screenshots"
+  '';
+
   launchd.agents.appearance-theme-switcher = {
     enable = true;
     config = {


### PR DESCRIPTION
`screencapture.location` and a dock `persistent-others` entry both point at `~/Pictures/screenshots`. On a fresh host that directory does not exist, so macOS silently falls back to `~/Desktop` for screenshots and the dock entry is empty.

Adds a `home.activation` (`mkdir -p ~/Pictures/screenshots`) in `home-manager-darwin.nix` so it always exists. From the brobot readiness audit (PR 4 of 5).