### PR TITLE
chore(flake): drop unused nixvim input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,27 +37,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -151,28 +130,6 @@
         "type": "github"
       }
     },
-    "nixvim": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1779621590,
-        "narHash": "sha256-kGu+wVVqu3ltT845pu3MtOGTW40rcCUVDW3JGffSpp0=",
-        "owner": "nix-community",
-        "repo": "nixvim",
-        "rev": "7259329db1e6145842411873d23b2dab577539a3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixvim",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -202,7 +159,6 @@
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable",
-        "nixvim": "nixvim",
         "pre-commit-hooks": "pre-commit-hooks",
         "sops-nix": "sops-nix"
       }
@@ -241,21 +197,6 @@
       "original": {
         "owner": "Mic92",
         "repo": "sops-nix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -25,10 +25,6 @@
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixvim = {
-      url = "github:nix-community/nixvim";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -105,7 +105,6 @@ systemFunc {
         users = usersHMConfig;
         sharedModules = [
           inputs.sops-nix.homeManagerModules.sops
-          inputs.nixvim.homeModules.nixvim
         ];
         extraSpecialArgs = {
           inherit inputs pkgs;


### PR DESCRIPTION
The `nixvim` input is declared and imported into home-manager `sharedModules`, but nothing sets `programs.nixvim.*` (nvim is handled by LazyVim via `modules/nvim.nix`). Removing it trims `flake.lock` and one home-manager module evaluation.

- remove the input (`flake.nix`) and the `sharedModules` import (`lib/mkSystem.nix`); relock.
- verified: no remaining `nixvim` refs, and goddard + carl both still evaluate.

From the brobot readiness audit (PR 5 of 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary dependency from the project configuration, reducing overall setup overhead.
  * Simplified the shared system configuration by no longer applying an extra editor-related module to all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->