### PR TITLE
feat(darwin): install and manage Homebrew via nix-homebrew

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "brew-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781226006,
+        "narHash": "sha256-w4ZTuOnhYiDxjaynrMTASzp802QblBWmo3wpB8wVN4Y=",
+        "owner": "Homebrew",
+        "repo": "brew",
+        "rev": "109191be4988470b51a60a5ef1998520aa24c01b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Homebrew",
+        "ref": "6.0.1",
+        "repo": "brew",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -119,6 +136,24 @@
         "type": "github"
       }
     },
+    "nix-homebrew": {
+      "inputs": {
+        "brew-src": "brew-src"
+      },
+      "locked": {
+        "lastModified": 1781389246,
+        "narHash": "sha256-ORqLAo/hoJdsZC7UPAuEHev6S0+XIqKEC7vjo5prz1k=",
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "rev": "de7953a08ed4bb9245be043e468561c17b89130d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "nix-homebrew",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779536132,
@@ -200,6 +235,7 @@
         "fenix": "fenix",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
+        "nix-homebrew": "nix-homebrew",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixvim": "nixvim",

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-homebrew.url = "github:zhaofengli/nix-homebrew";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -119,5 +119,7 @@ systemFunc {
   ]
   # User OS configurations (reversed to maintain priority)
   # ++ lib.lists.reverseList usersOSConfig;
-  ++ usersOSConfig;
+  ++ usersOSConfig
+  # nix-homebrew installs and manages Homebrew itself (darwin only).
+  ++ lib.optional darwin inputs.nix-homebrew.darwinModules.nix-homebrew;
 }

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -1,4 +1,13 @@
-_: {
+{ config, ... }:
+{
+  # Install and manage Homebrew itself so a fresh host needs no manual brew
+  # install; autoMigrate adopts an existing install (e.g. goddard).
+  nix-homebrew = {
+    enable = true;
+    user = config.system.primaryUser;
+    autoMigrate = true;
+  };
+
   homebrew = {
     enable = true;
     global = { };


### PR DESCRIPTION
Makes Homebrew part of the declarative setup so a fresh darwin host needs no manual `brew` install before the first switch — the one bootstrap step most likely to bite (the `homebrew.*` module manages casks/brews but never installed brew itself).

- add the `nix-homebrew` input. It has **no `nixpkgs` input**, so it's url-only — adding `inputs.nixpkgs.follows` emits a warning that would fail CI under `--option abort-on-warn true`.
- import `nix-homebrew.darwinModules.nix-homebrew` for darwin hosts only (`lib.optional darwin …` in `mkSystem`).
- enable it in `modules/darwin/homebrew.nix` (co-located with the casks): `user = config.system.primaryUser`, `autoMigrate = true`. It **composes** with the existing `homebrew.*` bundle — nix-homebrew provides `brew`, nix-darwin still installs the casks.

Verified: warning-free lock, `nix-homebrew` resolves on goddard + brobot, carl (nixos) still evaluates, and a full `nix build .#darwinConfigurations.goddard.system` succeeds (now includes `setup-homebrew`).

On goddard the next switch adopts the existing brew via `autoMigrate`; brobot installs it fresh.