### PR TITLE
fix(bootstrap): self-sufficient fresh-host bring-up

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -9,6 +9,15 @@ HOST="${HOST:-$(hostname -s)}"
 log() { printf '\033[0;32m[bootstrap]\033[0m %s\n' "$*"; }
 err() { printf '\033[0;31m[bootstrap]\033[0m %s\n' "$*" >&2; }
 
+# sops needs the age key present to decrypt secrets during the switch; fail early
+# with a clear message instead of a cryptic mid-activation error.
+AGE_KEY="$HOME/.config/sops/age/keys.txt"
+if [ ! -f "$AGE_KEY" ]; then
+  err "Missing sops age key at $AGE_KEY."
+  err "Copy it from another host (chmod 600) before bootstrapping — see docs/new-host-setup.md."
+  exit 1
+fi
+
 if ! command -v nix >/dev/null 2>&1; then
   log "Nix not found; installing via Determinate Systems installer..."
   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -18,7 +27,8 @@ fi
 
 if [ ! -d "$DOTFILES_PATH/.git" ]; then
   log "Cloning $REPO_URL into $DOTFILES_PATH..."
-  git clone "$REPO_URL" "$DOTFILES_PATH"
+  # Use nix-provided git so a fresh Mac needs no Xcode Command Line Tools.
+  nix run nixpkgs#git -- clone "$REPO_URL" "$DOTFILES_PATH"
 fi
 
 cd "$DOTFILES_PATH"
@@ -39,3 +49,4 @@ case "$(uname -s)" in
 esac
 
 log "Done. Open a new shell to pick up the home-manager environment."
+log "Manual follow-ups: grant Accessibility + Screen Recording when prompted (aerospace, sketchybar, jankyborders); set your default browser; install claude-code."


### PR DESCRIPTION
Makes the `curl | bash` one-liner work end-to-end on a *bare* Mac:

- **Preflight:** fail fast if the sops age key (`~/.config/sops/age/keys.txt`) is missing — a clear message instead of a cryptic mid-switch sops failure.
- **Clone via nix-provided git** (`nix run nixpkgs#git`): a fresh Mac has only a `git` shim that triggers the Xcode Command Line Tools prompt; since Nix is installed first, we use its git and skip the 1 GB+ CLT install.
- **Echo follow-ups** after the switch: the GUI-only leftovers (TCC grants, default browser, claude-code).

Verified: `bash -n` clean; shellcheck clean (only the pre-existing SC1091 info on the nix-daemon source line). From the brobot readiness audit.