### PR TITLE
feat(secrets): manage the GitHub SSH key via sops

### DIFF
--- a/users/romaingrx/secrets.nix
+++ b/users/romaingrx/secrets.nix
@@ -1,6 +1,12 @@
-{ config, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   gpg_sops_file = ./secrets/gpg.yaml;
+  ssh_sops_file = ./secrets/ssh.yaml;
   inherit (config.home) homeDirectory;
 in
 {
@@ -13,6 +19,15 @@ in
       "gpg_github_private_key" = {
         path = "${homeDirectory}/.config/gnupg/private.key";
         sopsFile = gpg_sops_file;
+        mode = "0600";
+      };
+    }
+    # The GitHub SSH key, decrypted to where ssh.nix expects it. Inert until
+    # secrets/ssh.yaml exists — add it with: sops users/romaingrx/secrets/ssh.yaml
+    // lib.optionalAttrs (builtins.pathExists ssh_sops_file) {
+      "github_ssh_private_key" = {
+        path = "${homeDirectory}/.ssh/github";
+        sopsFile = ssh_sops_file;
         mode = "0600";
       };
     };

--- a/users/romaingrx/secrets.nix
+++ b/users/romaingrx/secrets.nix
@@ -33,6 +33,10 @@ in
     };
   };
 
+  # Let the sops CLI find the age key at the same path activation uses
+  # (macOS defaults to ~/Library/Application Support, not ~/.config).
+  home.sessionVariables.SOPS_AGE_KEY_FILE = config.sops.age.keyFile;
+
   # Updated activation script for GPG key import
   home.activation = {
     importGpgKey =


### PR DESCRIPTION
Makes the **sops age key the single root secret** for a new host — the GitHub SSH key now comes from sops, decrypted to `~/.ssh/github` (where `ssh.nix` already points), mode `0600`. No `ssh.nix` change.

**pathExists-guarded** on `secrets/ssh.yaml`: inert until that file exists, so merging before the key is added cannot break a switch.

Also sets **`home.sessionVariables.SOPS_AGE_KEY_FILE = config.sops.age.keyFile`** so the manual `sops` CLI finds the age key on macOS (which otherwise defaults to `~/Library/Application Support`, not `~/.config`).

### Required before this activates — you add the key
Your private key never passes through CI or me:
```sh
export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"   # until the next switch makes it automatic
sops users/romaingrx/secrets/ssh.yaml      # add:  github_ssh_private_key: |  <your ~/.ssh/github>
git add users/romaingrx/secrets/ssh.yaml && git commit && git push
```
On goddard, paste goddard's current `~/.ssh/github` so the switch is a no-op. From the brobot readiness audit.