### PR TITLE
feat(secrets): add encrypted GitHub SSH key

### DIFF
--- a/users/romaingrx/secrets/ssh.yaml
+++ b/users/romaingrx/secrets/ssh.yaml
@@ -1,0 +1,25 @@
+github_ssh_private_key: ENC[AES256_GCM,data:t+CcMCY6Fm+7+p/lrfkAEbBWnOLzAKWfva0+KYUi7mckXRSq8zODXzfohQfT9qIdXO3yO/vLMa+tHDcXQb/mfVkfipkjRibFaaTrYg/6CoIpwTjgVaztA3fI6Ya9NN+wQ4eEhRErjYhPrF4GbYSjkBeUL7Xdbtot9/tEdzyVkBIP1G0ZM2XlVPuZwlEi6cyAFNYDS8rzoip1RGskDKM9OEt/fz7X7Gw4mzxFa9ixo8DRwRIPGKpVA/c/zVjSWPqNFEOSoOLjBHmLYtKGNrup2P6GTtIkmpa8j+t31Uuwm0HYRzKLGY2/14RsRY/OxUJJ/CWrY/5Il+xj5tKGUhRsn2e1eamVTlbE7yKBvgzmFITFHrwmwvShXwgZO4Aj6z8YscyxrWhQJTeYeyEGRIsTGmr3JjYjizAyNKt6RgGLWapiCRoexawh2DTlfG4pBIYusIBzM+XseyfXFAKKfsdT9IYxCH862fxk3WakGbn4fJMAR5R1LZI8HD4S/0Bk73D8kNxxw11RSXOlgvH+83Q8dfjWxloBTBSlLFP1p7tVRGXzKgawuRGNOmrD1QKj4LBj7KpVQJSgcEBtLyOgwqZa66Jg8tNU+haX2O8SUUZuwNlY2iB7QvBmCZ//O5Ur+oG3yj4KUg==,iv:YVbuvv7S6jzUmj8b8GdhZUju19+RRKfvK9EIa0cVm2w=,tag:h3R5JYmQDqnweOKi2vDf7Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHUm8vN3dDK3p1OXY5MUxs
+            cVR2MURObURYUUgwN2k5UUFYQ2Rlc3Y3TEdrCmdSdnVRdlVpN0RVblVHNVFWY2ls
+            SzhFWUNpNmRZNnloekNRalBCd01FTDgKLS0tIGRwV1Bjc3h6Q3YvbXp2bUZKcFc2
+            RTM4cmJBSXR5WjV3SjlvdFVOMm16SDAK4qz+lxuZJhqCoC2zIa0H1kD264yTzcNh
+            QV083+uymnRCLohXvMPuJRatmU3Ac8HiSj4EvZLTVTaGaSNciKCXSA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age18r9akfvujxryr4kpc4a34agsvkqczkl6gf8aaq98jmaqyl4tt42snpac6f
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlYVM2ZGhTcGNuMTd5WnNQ
+            YWllTmhyZFVaM0xEZ3FqZnFUQlltVWdLZHhvCm1jMjRoVW1zTU16SURxZkZKV2RC
+            L1lpUW8waGViZTl1cUYwTzN4RlcvSFEKLS0tIHUzYXB1eUdSNFI0RU05aW4wZFdu
+            YWd2bndnYi9kTnd3NFJaNDd3bS9mbTQKdp0H0lHC6jK9uubhBvQItVpAAhCxzLqZ
+            WUgdYFAl7aQOqeQnWo+6zr5slEodVoNvccnAk1gI46IIVXfSOLMyoA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1md2t0hzlag085jflzvk2unss9v2gqpe8qscxzzeues2nzpfgt3nqeu2h9h
+    lastmodified: "2026-06-28T21:32:58Z"
+    mac: ENC[AES256_GCM,data:VDZbQLxPqnHQx6DWUneVC+GdwKw2Rd8rM3atGDrpf8TkOWrZfYhucH07z+CXxhdlNb86kLDcugkKPITJMXo3O0bGlqyl4LgPgLrjoBoXxdj9d0MgM4W0PVnOfpeSj9xQuu1bLgYdPjITA1S53R5YiKAePLc51hV8u5uT3XTRBtk=,iv:U4AJxvKh9udj0CIkOneP6Y8GQhCxci/C9VIqUEk30us=,tag:jYf9yoCjF8K62WoAzaUbiQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1


### PR DESCRIPTION
Completes #65 — adds the sops-encrypted GitHub SSH key so the `pathExists`-guarded `github_ssh_private_key` secret activates (decrypts to `~/.ssh/github`, mode 0600, on switch). The age key now unlocks both GPG and SSH → a new host needs only the age key.

Encrypted (ciphertext only), safe to commit. Verified: sops metadata present, key name matches, `sops -d --extract` succeeds, and the secret appears in the evaluated brobot config.