### PR TITLE
chore(flake): update all inputs to current (lockstep)

### DIFF
--- a/checks/pre-commit.nix
+++ b/checks/pre-commit.nix
@@ -15,7 +15,14 @@
         excludes = [ "third-party/" ];
       };
       deadnix.enable = true;
-      statix.enable = true;
+      statix = {
+        enable = true;
+        # statix's own tests fail to build on current nixpkgs; skip them (the
+        # linter works). Drop the override once fixed upstream.
+        package = pkgs.statix.overrideAttrs (_: {
+          doCheck = false;
+        });
+      };
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1779612045,
-        "narHash": "sha256-+7lfNVnmXJDkiRYHd5NoNwYoyUcc0LcXPaIJqjO7VWM=",
+        "lastModified": 1782638651,
+        "narHash": "sha256-+pFKu+a/YWhPUaBj5cIa7PLNcDvpzpgzuZm+jeFJC38=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d7be747f0a65af378de515fc3cee131bf99a008f",
+        "rev": "7f6d415487ef6d5dfe08c4bda148af3d21477dec",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779627636,
-        "narHash": "sha256-J6JGf42zNzLo/CrRdKb5dNznpLI+eGxN/5KTLG1Mo5s=",
+        "lastModified": 1782702263,
+        "narHash": "sha256-8/MG4Su7PhnynrmsVO61IeAfrK7GuUEu+E+gwbhy1QQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "044c30c19550c0557997dece4ce9e54d2fa77ba1",
+        "rev": "789a35fbdeb3c46b260096daa0b321c11be527ea",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1782636521,
+        "narHash": "sha256-OG8laCOGtkxlB1JH3XqOnXxnkGJme4mQdXo5hkhCQIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "e1c1b84752fb0897897380a3cae9dc7fcab91ca3",
         "type": "github"
       },
       "original": {
@@ -174,11 +174,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779569060,
-        "narHash": "sha256-NSnk5D+3KEfRdbgPijs33N2RAKSG6A74SwfnynLcouo=",
+        "lastModified": 1782591962,
+        "narHash": "sha256-uNO+yWCw+EogXBbj4uRLWYfmOjAzeDhWs1JL+E5niK4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "987ea33645ab1c709b1df6823038abcb2fe8973e",
+        "rev": "5d15d9f5fd939bd8f121ae878d55b30e6a992a32",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1782165805,
+        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   description = "Goddard nix-darwin system flake";
 
   inputs = {
-    # Remote
+    # Remote inputs track the unstable / master channels. Always update them
+    # together (`nix flake update`) — never bump one alone, or nix-darwin's
+    # release check fails against a skewed nixpkgs. Renovate's
+    # lockFileMaintenance performs this lockstep refresh automatically.
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
     nix-darwin = {
@@ -83,7 +86,11 @@
             buildInputs = with pkgs; [
               nixfmt
               deadnix
-              statix
+              # statix's own tests fail to build on current nixpkgs; skip them
+              # (the linter works). Drop the override once fixed upstream.
+              (statix.overrideAttrs (_: {
+                doCheck = false;
+              }))
               pre-commit
             ];
           };


### PR DESCRIPTION
## What

A full `nix flake update` — every input advances **together** (nixpkgs, nix-darwin, home-manager + the rest), keeping the unstable channel in lockstep.

### Wins
- **Current software** across the board.
- **Fixes the Homebrew cleanup prompt.** Current nix-darwin emits `brew bundle … --force-cleanup` (non-interactive) instead of the deprecated `--cleanup`, so activation no longer stops on `Do you want to proceed with the cleanup? [y/n]`.

### statix workaround (temporary, no overlay)
Current nixpkgs ships a `statix` whose build-time `insta` snapshot tests fail, so it won't build → `nix flake check` would be red. The linter itself is fine, so we override `doCheck = false` **inline at the two spots statix is used** — the pre-commit hook (`checks/pre-commit.nix`) and the dev shell (`flake.nix`). No overlay, no extra plumbing; `pkgs` stays `legacyPackages`. **Drop the override once fixed upstream.**

Also adds a comment by the inputs documenting the lockstep rule.

## Verification (local)
- `goddard`, `brobot`, `carl` all evaluate.
- `nix build .#darwinConfigurations.goddard.system` → builds clean.
- `nix build .#checks.aarch64-darwin.pre-commit-check` → builds; deadnix / nixfmt / statix all pass.

## Test plan before merge
Canary on goddard: `sudo darwin-rebuild switch --flake .#goddard` from this branch, confirm activation runs clean with no cleanup prompt.

Companion to #67 (renovate consolidation).