### PR TITLE
chore(darwin): move kept CLI tools from Homebrew to nixpkgs

### DIFF
--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -38,14 +38,6 @@
       # version so a fresh host needs no App Store sign-in. Same /Applications path.
       "tailscale-app"
     ];
-    brews = [
-      "watch"
-      "ffmpeg"
-      "mactop"
-      "libpq"
-      "yt-dlp"
-      "awscli"
-      "mas"
-    ];
+    brews = [ ];
   };
 }

--- a/modules/home/packages.nix
+++ b/modules/home/packages.nix
@@ -38,5 +38,10 @@
       obsidian
       slack
     ]
-    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [ raycast ];
+    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      raycast
+      mactop
+      watch
+      mas
+    ];
 }


### PR DESCRIPTION
## Why
Homebrew brews don't upgrade with `onActivation.upgrade = false`, so the CLI tools sat frozen at install time. Move the ones we keep to nixpkgs (pinned + refreshed by the lockstep update); drop the rest.

## Changes
- **`mactop`, `watch`, `mas`** → nixpkgs, Darwin section of `modules/home/packages.nix`.
- **`ffmpeg`, `yt-dlp`, `libpq` dropped** (unused).
- **`awscli` dropped** — `awscli2` was already in `home.packages`.
- **`brews` list now empty** — Homebrew manages only GUI casks.

The nixpkgs/cask deletions + de-duplication are handled in a follow-up cleanup PR.