### PR TITLE
refactor: rename bootstrap.sh to install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ nix flake check
 Bootstrap a fresh machine (installs Nix, clones to `~/.dotfiles`, switches):
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/install.sh | bash
 ```
 
 See [docs/new-host-setup.md](docs/new-host-setup.md) for the manual prerequisites (the sops age key, plus a couple of permission grants).

--- a/docs/new-host-setup.md
+++ b/docs/new-host-setup.md
@@ -1,6 +1,6 @@
 # New macOS host
 
-`scripts/bootstrap.sh` installs Nix, clones to `~/.dotfiles`, and switches —
+`scripts/install.sh` installs Nix, clones to `~/.dotfiles`, and switches —
 Homebrew, the SSH and GPG keys (via sops), and everything else come from the switch.
 
 ## Before
@@ -11,7 +11,7 @@ It's the only secret you carry over — the GPG and SSH keys decrypt from it on 
 ## Bootstrap
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/bootstrap.sh | HOST=brobot bash
+curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/install.sh | HOST=brobot bash
 ```
 
 `HOST` defaults to `hostname -s`; the repo must land at `~/.dotfiles`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,8 @@ REPO_URL="${REPO_URL:-https://github.com/romaingrx/dotfiles.git}"
 DOTFILES_PATH="${DOTFILES_PATH:-$HOME/.dotfiles}"
 HOST="${HOST:-$(hostname -s)}"
 
-log() { printf '\033[0;32m[bootstrap]\033[0m %s\n' "$*"; }
-err() { printf '\033[0;31m[bootstrap]\033[0m %s\n' "$*" >&2; }
+log() { printf '\033[0;32m[install]\033[0m %s\n' "$*"; }
+err() { printf '\033[0;31m[install]\033[0m %s\n' "$*" >&2; }
 
 # sops needs the age key present to decrypt secrets during the switch; fail early
 # with a clear message instead of a cryptic mid-activation error.


### PR DESCRIPTION
Renames the installer so it matches the public vanity URL `romaingrx.com/dotfiles/install.sh` end-to-end — `install.sh` is the conventional `curl | bash` name, and the redirect becomes a plain domain alias rather than a name translation.

- `git mv scripts/bootstrap.sh scripts/install.sh` (git detects it as a rename)
- update the `curl` one-liners in `README.md` + `docs/new-host-setup.md`
- `[bootstrap]` log label → `[install]`

Pairs with romaingrx/romaingrx.com#35, whose redirect target is repointed to `…/scripts/install.sh`. **Merge this first** so the raw URL exists before that redirect goes live.