### PR TITLE
docs: concise feature-focused README + vanity install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,29 @@
-[![check](https://github.com/romaingrx/dotfiles/actions/workflows/check.yml/badge.svg)](https://github.com/romaingrx/dotfiles/actions/workflows/check.yml)
-[![build](https://github.com/romaingrx/dotfiles/actions/workflows/build.yml/badge.svg)](https://github.com/romaingrx/dotfiles/actions/workflows/build.yml)
+[![check](https://github.com/romaingrx/dotfiles/actions/workflows/check.yml/badge.svg)](https://github.com/romaingrx/dotfiles/actions/workflows/check.yml) [![build](https://github.com/romaingrx/dotfiles/actions/workflows/build.yml/badge.svg)](https://github.com/romaingrx/dotfiles/actions/workflows/build.yml)
 
-> My dotfiles for macOS and Linux using Nix, home-manager, and nix-darwin.
+> macOS + Linux dotfiles on Nix — nix-darwin, home-manager, and NixOS.
 
-> [!Warning]
-> Note that this configuration is actively evolving. While functional, some components are still being refined and optimized to ensure the best possible implementation.
-
-## Overview
-
-This repository contains my system configurations managed through Nix. It supports both macOS (via nix-darwin) and Linux (NixOS), with a focus on maintaining a consistent development environment across different machines.
-
-## Repository Structure
-
-```
-.
-├── assets/          # Assets like wallpapers and images
-├── config/          # Application configuration linked by home-manager
-├── hosts/           # Host-specific configurations (e.g. nixos, darwin)
-├── lib/             # Helper functions and utilities
-├── modules/         # Shared configuration modules
-├── overlays/        # Nix package overlays
-├── scripts/         # Bootstrap and helper scripts
-└── users/           # User-specific configurations
-```
-
-## Key Components
-
-- **Flake-based**: Uses Nix flakes for reproducible builds and dependencies
-- **Multi-user**: Supports different user configurations on the same machine
-- **Cross-platform**: Works on both MacOS (via nix-darwin) and Linux (NixOS)
-- **Modular**: Configurations are split into reusable modules
-
-## Supported Systems
-
-- **macOS (aarch64-darwin)**
-  - Primary configuration for `goddard` machine
-  
-- **Linux (x86_64-linux)**
-  - NixOS configuration for `carl` machine
-
-## Common Commands
+## Install
 
 ```sh
-nix develop
+curl -fsSL https://romaingrx.com/dotfiles/install.sh | bash
+```
+
+Installs Nix, clones to `~/.dotfiles`, and activates the host (`HOST=<name>` to pick a config; defaults to the hostname). The only secret you carry over is the sops age key — see [docs/new-host-setup.md](docs/new-host-setup.md).
+
+## Features
+
+- **One flake, many hosts.** A shared base with thin per-host overrides drives macOS (`goddard`, `brobot`, via nix-darwin) and NixOS (`carl`) alike — a new host is one flake entry plus an optional override file.
+- **Declarative end to end.** Packages, macOS defaults, fonts, and the handful of Homebrew casks Nix can't own all come from the flake — no manual install steps.
+- **One key for every secret.** A single sops age key decrypts the GPG and SSH keys at activation; nothing else is copied onto a new machine.
+- **Theming that follows the system.** A light/dark theme contract drives the terminal, sketchybar, and the rest, switching automatically with macOS appearance.
+- **Reproducible and self-maintaining.** Inputs are pinned in `flake.lock` and refreshed in lockstep by Renovate; CI evaluates and builds every host on each PR.
+
+## Develop
+
+```sh
+nix develop          # dev shell: nixfmt, deadnix, statix, pre-commit
+nix flake check      # eval + lint every host
 nix fmt
-nix flake check
 ```
 
-Bootstrap a fresh machine (installs Nix, clones to `~/.dotfiles`, switches):
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/install.sh | bash
-```
-
-See [docs/new-host-setup.md](docs/new-host-setup.md) for the manual prerequisites (the sops age key, plus a couple of permission grants).
-
-## Known Issues and Limitations
-
-### macOS (Darwin)
-- **Homebrew Multi-user Support**: The current implementation doesn't handle Homebrew packages well in a multi-user setup. Package management and sharing between users needs improvement.
-- **Package Sharing**: Limited capability for sharing packages between users in the Darwin setup, especially around `sketchybar`.
-
-## Documentation
-
-> [!Note]
-> In progress.
+`hosts/` per-host · `modules/` shared · `users/` · `overlays/` · `config/` app configs · `lib/` · `scripts/`

--- a/docs/new-host-setup.md
+++ b/docs/new-host-setup.md
@@ -11,7 +11,7 @@ It's the only secret you carry over — the GPG and SSH keys decrypt from it on 
 ## Bootstrap
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/romaingrx/dotfiles/main/scripts/install.sh | HOST=brobot bash
+curl -fsSL https://romaingrx.com/dotfiles/install.sh | HOST=brobot bash
 ```
 
 `HOST` defaults to `hostname -s`; the repo must land at `~/.dotfiles`.


### PR DESCRIPTION
Rewrites the README to be short and **feature-focused** — what the repo does, not an exhaustive listing.

- Replaces the verbose Overview / structure tree / Common Commands / Known Issues / empty Documentation sections with a tight **Features** list (multi-host flake, declarative end-to-end, one-key secrets, system-following theming, reproducible + Renovate-automated).
- Fixes stale claims: drops "multi-user" (hosts are single-user now), adds `brobot`, removes the outdated Homebrew known-issues.
- Points the install one-liner (README + `docs/new-host-setup.md`) at the now-live **`https://romaingrx.com/dotfiles/install.sh`**.

70 → 17 lines.