### PR TITLE
feat(brobot): add ffmpeg, MongoDB Compass, and Notion

### DIFF
--- a/hosts/darwin/brobot/default.nix
+++ b/hosts/darwin/brobot/default.nix
@@ -11,8 +11,11 @@
 
   system.defaults.loginwindow.LoginwindowText = "Hand-built, loyal, little brother";
 
-  # MongoDB Compass GUI — brobot-only, list-merges with the shared casks.
-  homebrew.casks = [ "mongodb-compass" ];
+  # MongoDB Compass + Notion GUIs — brobot-only, list-merge with the shared casks.
+  homebrew.casks = [
+    "mongodb-compass"
+    "notion"
+  ];
 
   # Host-only overrides live with the host:
   #   - system/darwin (dock, casks, macOS defaults) -> here, e.g.

--- a/hosts/darwin/brobot/default.nix
+++ b/hosts/darwin/brobot/default.nix
@@ -11,6 +11,9 @@
 
   system.defaults.loginwindow.LoginwindowText = "Hand-built, loyal, little brother";
 
+  # MongoDB Compass GUI — brobot-only, list-merges with the shared casks.
+  homebrew.casks = [ "mongodb-compass" ];
+
   # Host-only overrides live with the host:
   #   - system/darwin (dock, casks, macOS defaults) -> here, e.g.
   #       homebrew.casks = [ "some-app" ];                          # list-merges with the shared set

--- a/hosts/darwin/brobot/home.nix
+++ b/hosts/darwin/brobot/home.nix
@@ -1,0 +1,5 @@
+{ pkgs, ... }:
+{
+  # brobot-only CLI packages (auto-imported by mkSystem when present).
+  home.packages = [ pkgs.ffmpeg ];
+}


### PR DESCRIPTION
Installs `ffmpeg`, MongoDB Compass, and Notion on the **brobot** host only.

- **Compass** + **Notion** (GUIs) → `mongodb-compass` and `notion` casks in `hosts/darwin/brobot/default.nix`, list-merge with the shared casks.
- **ffmpeg** (CLI) → `home.packages` in a new `hosts/darwin/brobot/home.nix`, auto-imported by `mkSystem`.

Both routes scoped to brobot as documented in the host config comment. `nix eval` of the brobot config passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)