### PR TITLE
fix(darwin): install Raycast as a Homebrew cask

### DIFF
--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -83,7 +83,7 @@
         persistent-apps = [
           "/System/Applications/Mail.app"
           "/System/Applications/Calendar.app"
-          "${pkgs.raycast}/Applications/Raycast.app"
+          "/Applications/Raycast.app"
         ];
         # persistent-others is set via CustomUserPreferences below so we can
         # pin each stack's sort order (arrangement = 4 -> Date Created, newest

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -33,6 +33,7 @@
       "arc"
       "claude"
       "linear"
+      "raycast"
       # Standalone, self-updating Tailscale GUI — replaces the Mac App Store
       # version so a fresh host needs no App Store sign-in. Same /Applications path.
       "tailscale-app"

--- a/modules/home/packages.nix
+++ b/modules/home/packages.nix
@@ -33,7 +33,6 @@
       slack
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-      raycast
       mactop
       watch
       mas


### PR DESCRIPTION
## Why

Raycast was declared in `home.packages` (de-duplicated there in #70). On Darwin, though, `home.packages` builds a GUI app into the Nix store without linking it into a launchable `/Applications` location — the `~/Applications/Home Manager Apps` folder stays empty, so Raycast isn't Spotlight-visible or reliably launchable. It looked like it had been removed.

The repo already provisions every other GUI app as a self-updating Homebrew cask (#59: 1Password, Arc, Claude, Linear, …). Raycast is a GUI launcher and belongs with them; nixpkgs stays reserved for CLI tools (#69).

## Changes

- Add the `raycast` cask alongside the other daily-driver GUI apps (all self-update via `auto_updates`, so `onActivation.upgrade` stays off).
- Drop `raycast` from the Darwin section of `home.packages`.
- Point the Dock pin at `/Applications/Raycast.app` (where the cask lands, same as `tailscale-app`) instead of the Nix store path.

## Verification

- `goddard` evaluates: `homebrew.casks` includes `raycast`, and the Dock pin resolves to `/Applications/Raycast.app` with no Nix store path leaked.
- deadnix / nixfmt / statix pass.

Apply with `darwin-rebuild switch --flake .#<host>`; Homebrew installs the cask into `/Applications`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
