### PR TITLE
fix(sketchybar): disable bar shadow to stop blur flicker

### DIFF
--- a/config/sketchybar/sketchybarrc
+++ b/config/sketchybar/sketchybarrc
@@ -27,12 +27,12 @@ if [ -n "${SKETCHYBAR_APP_FONT_PATH:-}" ] && [ -r "$SKETCHYBAR_APP_FONT_PATH" ];
 fi
 
 sketchybar --bar height=30 \
-	blur_radius=100 \
+	blur_radius=30 \
 	position=top \
 	padding_left=10 \
 	padding_right=10 \
 	color="$BAR_BG" \
-	shadow=on
+	shadow=off
 
 sketchybar --default updates=when_shown \
 	drawing=on \


### PR DESCRIPTION
Turn the bar shadow off (and lower `blur_radius`) so the translucent bar stops flickering as window content moves behind it.

Upstream-confirmed shadow×blur bug on SketchyBar 2.24.0 — [#827](https://github.com/FelixKratz/SketchyBar/issues/827). Scoped to `sketchybarrc`; verified live with `sketchybar --bar shadow=off blur_radius=30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
